### PR TITLE
use newlib-nano to saving sram usage of impure_data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 # Compiler options here.
 ifeq ($(USE_OPT),)
-  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16 --specs=nano.specs
 endif
 
 # C specific options here (added to USE_OPT).


### PR DESCRIPTION
特に追加の実装ではないのですが、SRAM 使用量が厳しいため .map  を見ていたところ、impure_data が約 1kB ほど領域を使っており、これがそれなりに支配的だったため、newlib-nano を使うようにしてみました。newlib-nano だと impure_data は 96bytes のようで、けっこう削減されます。

軽く試した感じでは正常に動いていそうです。sprintf の %f が動かなくなるらしいですが、こちらのプロジェクトでは ch*printf が使われていますし、これの float 対応は CHPRINTF_USE_FLOAT フラグによる分岐の独自実装のため問題なさそうです。

あとは IDLE スレッドをやめて main スレッドを idle スレッドにすれば、idle スレッドの ch_idle_thread_wa 200 バイト分を減らせそうですが変更点が多かったためやめました。

既に検討済みでしたらすみません。

.data .bss 解析:

before:
```
... snip ...
  0%         48 shell_local_commands
  0%         48 DACD2
  0%         52 SPID1
  0%         56 I2CD1
  0%         56 _stm32_dma_isr_redir
  0%         96 samp_buf
  0%         96 ref_buf
  0%        104 ch
  0%        124 SD1
  0%        132 USBD1
  1%        192 dump_buffer
  1%        208 ch_idle_thread_wa
  2%        384 SDU1
  2%        384 rx_buffer
  4%        640 waThread2
  6%        960 waThread1
  7%       1064 impure_data
 10%       1616 measured
 10%       1616 trace_index
 13%       2048 spi_buffer
 30%       4552 current_props
total: 15081 bytes
```

after:
```
... snip ...
  0%         48 shell_local_commands
  0%         48 DACD2
  0%         48 DACD1
  0%         52 SPID1
  0%         56 I2CD1
  0%         56 _stm32_dma_isr_redir
  0%         96 samp_buf
  0%         96 impure_data
  0%         96 ref_buf
  0%        104 ch
  0%        124 SD1
  0%        132 USBD1
  1%        192 dump_buffer
  1%        208 ch_idle_thread_wa
  2%        384 rx_buffer
  2%        384 SDU1
  4%        640 waThread2
  6%        960 waThread1
 11%       1616 measured
 11%       1616 trace_index
 14%       2048 spi_buffer
 32%       4552 current_props
total: 14113 bytes
```