### PR TITLE
static inline reduces stack memory usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 # Compiler options here.
 ifeq ($(USE_OPT),)
-  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16 --specs=nano.specs
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16 --specs=nano.specs -fstack-usage
 endif
 
 # C specific options here (added to USE_OPT).

--- a/chconf.h
+++ b/chconf.h
@@ -526,6 +526,19 @@
 
 #define CHPRINTF_USE_FLOAT          TRUE
 
+/**
+ * ChibiOS/os/various/shell/shell_cmd.c
+ */
+#define SHELL_CMD_EXIT_ENABLED TRUE
+#define SHELL_CMD_INFO_ENABLED TRUE
+#define SHELL_CMD_ECHO_ENABLED FALSE
+#define SHELL_CMD_SYSTIME_ENABLED FALSE
+#define SHELL_CMD_MEM_ENABLED FALSE
+#define SHELL_CMD_THREADS_ENABLED TRUE
+#define SHELL_CMD_TEST_ENABLED FALSE
+
+
+
 #endif  /* _CHCONF_H_ */
 
 /** @} */

--- a/main.c
+++ b/main.c
@@ -53,7 +53,7 @@ int8_t cal_auto_interpolate = TRUE;
 int8_t redraw_requested = FALSE;
 int8_t stop_the_world = FALSE;
 
-static THD_WORKING_AREA(waThread1, 768);
+static THD_WORKING_AREA(waThread1, 640);
 static THD_FUNCTION(Thread1, arg)
 {
     (void)arg;
@@ -1289,7 +1289,7 @@ const struct {
   { "X",      4, 100 }
 };
 
-const char *trc_channel_name[] = {
+const char * const trc_channel_name[] = {
   "CH0", "CH1"
 };
 
@@ -1737,8 +1737,7 @@ static void cmd_version(BaseSequentialStream *chp, int argc, char *argv[])
   chprintf(chp, "%s\r\n", NANOVNA_VERSION);
 }
 
-#define SHELL_WA_SIZE THD_WORKING_AREA_SIZE(256)
-static THD_WORKING_AREA(waThread2, SHELL_WA_SIZE);
+static THD_WORKING_AREA(waThread2, /* cmd_* max stack size + alpha */410);
 
 static const ShellCommand commands[] =
 {

--- a/plot.c
+++ b/plot.c
@@ -7,7 +7,7 @@
 
 #define SWAP(x,y) do { int z=x; x = y; y = z; } while(0)
 
-void cell_draw_marker_info(int m, int n, int w, int h);
+static void cell_draw_marker_info(int m, int n, int w, int h);
 void draw_frequencies(void);
 void frequency_string(char *buf, size_t len, int32_t freq);
 void markmap_all_markers(void);
@@ -534,7 +534,7 @@ trace_into_index(int x, int t, int i, float coeff[2])
   return INDEX(x +CELLOFFSETX, y, i);
 }
 
-int
+static int
 string_value_with_prefix(char *buf, int len, float val, char unit)
 {
   char prefix;
@@ -591,7 +591,7 @@ string_value_with_prefix(char *buf, int len, float val, char unit)
 
 #define PI2 6.283184
 
-void
+static void
 gamma2imp(char *buf, int len, const float coeff[2], uint32_t frequency)
 {
   // z = (gamma+1)/(gamma-1) * z0
@@ -613,7 +613,7 @@ gamma2imp(char *buf, int len, const float coeff[2], uint32_t frequency)
   }
 }
 
-void
+static void
 gamma2resistance(char *buf, int len, const float coeff[2], uint32_t frequency)
 {
   float z0 = 50;
@@ -622,7 +622,7 @@ gamma2resistance(char *buf, int len, const float coeff[2], uint32_t frequency)
   string_value_with_prefix(buf, len, zr, S_OHM[0]);
 }
 
-void
+static void
 gamma2reactance(char *buf, int len, const float coeff[2], uint32_t frequency)
 {
   float z0 = 50;
@@ -631,7 +631,7 @@ gamma2reactance(char *buf, int len, const float coeff[2], uint32_t frequency)
   string_value_with_prefix(buf, len, zi, S_OHM[0]);
 }
 
-void
+static void
 trace_get_value_string(int t, char *buf, int len, float coeff[2], uint32_t frequency)
 {
   float v;
@@ -721,7 +721,7 @@ markmap_upperarea(void)
   markmap[current_mappage][0] |= 0xffff;
 }
 
-static void
+static inline void
 swap_markmap(void)
 {
   current_mappage = 1 - current_mappage;
@@ -733,7 +733,7 @@ clear_markmap(void)
   memset(markmap[current_mappage], 0, sizeof markmap[current_mappage]);
 }
 
-void
+void inline
 force_set_markmap(void)
 {
   memset(markmap[current_mappage], 0xff, sizeof markmap[current_mappage]);
@@ -1107,7 +1107,7 @@ markmap_all_markers(void)
 }
 
 
-void
+static void
 draw_cell(int m, int n)
 {
   int x0 = m * CELLWIDTH;
@@ -1330,7 +1330,7 @@ cell_drawstring_invert_5x7(int w, int h, char *str, int x, int y, uint16_t fg, i
   }
 }
 
-void
+static void
 cell_draw_marker_info(int m, int n, int w, int h)
 {
   char buf[24];

--- a/ui.c
+++ b/ui.c
@@ -112,7 +112,7 @@ void draw_menu(void);
 void leave_ui_mode(void);
 void erase_menu_buttons(void);
 void ui_process_keypad(void);
-void ui_process_numeric(void);
+static void ui_process_numeric(void);
 
 static void menu_push_submenu(const menuitem_t *submenu);
 
@@ -1042,7 +1042,7 @@ const keypads_t keypads_time[] = {
   { 0, 0, -1 }
 };
 
-const keypads_t *keypads_mode_tbl[] = {
+const keypads_t * const keypads_mode_tbl[] = {
   keypads_freq, // start
   keypads_freq, // stop
   keypads_freq, // center
@@ -1053,7 +1053,7 @@ const keypads_t *keypads_mode_tbl[] = {
   keypads_time // electrical delay
 };
 
-const char *keypad_mode_label[] = {
+const char * const keypad_mode_label[] = {
   "START", "STOP", "CENTER", "SPAN", "CW FREQ", "SCALE", "REFPOS", "EDELAY"
 };
 
@@ -1409,7 +1409,7 @@ ui_mode_normal(void)
   ui_mode = UI_NORMAL;
 }
 
-void
+static void
 ui_process_normal(void)
 {
   int status = btn_check();
@@ -1438,7 +1438,7 @@ ui_process_normal(void)
   }
 }
 
-void
+static void
 ui_process_menu(void)
 {
   int status = btn_check();
@@ -1463,7 +1463,7 @@ ui_process_menu(void)
   }
 }
 
-int
+static int
 keypad_click(int key) 
 {
   int c = keypads[key].c;
@@ -1527,7 +1527,7 @@ keypad_click(int key)
   return KP_CONTINUE;
 }
 
-int
+static int
 keypad_apply_touch(void)
 {
   int touch_x, touch_y;
@@ -1556,7 +1556,7 @@ keypad_apply_touch(void)
   return -1;
 }
 
-void
+static void
 numeric_apply_touch(void)
 {
   int touch_x, touch_y;
@@ -1597,7 +1597,7 @@ numeric_apply_touch(void)
   return;
 }
 
-void
+static void
 ui_process_numeric(void)
 {
   int status = btn_check();
@@ -1720,7 +1720,7 @@ ui_process_keypad(void)
   touch_start_watchdog();
 }
 
-void
+static void
 ui_process_lever(void)
 {
   switch (ui_mode) {
@@ -1740,7 +1740,8 @@ ui_process_lever(void)
 }
 
 
-void drag_marker(int t, int m)
+static void
+drag_marker(int t, int m)
 {
   int status;
   /* wait touch release */
@@ -1767,7 +1768,7 @@ sq_distance(int x0, int y0)
   return x0*x0 + y0*y0;
 }
 
-int
+static int
 touch_pickup_marker(void)
 {
   int touch_x, touch_y;
@@ -1807,7 +1808,7 @@ touch_pickup_marker(void)
 }
 
 
-
+static
 void ui_process_touch(void)
 {
   awd_count++;


### PR DESCRIPTION
結果的には劇的に減るわけではないのですが、スレッドワーキングエリアの確保領域をスタック消費を中心に少し最適化して余裕を作るパッチになります。それぞれ微々たるものなのでまとめてしまいましたが、もしよければ部分的にでもとりこんでいただけると嬉しいです。

* static 指定して最大スタック消費量が減る関数を static 化 (inline 化)
* 定数ポインタ配列に const を追加 
* Thread1 のスタック消費量が減ったため割当を削減 (特に他の実装追加したわけではないので、減らしておく必要はありませんが……)
* Thread2 のスタック割当の変更 (不明点があったのでコードコメントを書きます)

before
```
  4%        640 waThread2
  6%        960 waThread1
 11%       1616 trace_index
 11%       1616 measured
 14%       2048 spi_buffer
 31%       4552 current_props
sram:  15136/16384 (92%)
flash: 83848/131072 (63%)
```

static stack usage analysis from .su
```
> Thread1                                                 800       28       16
> cmd_freq                                                400       20       12
> cmd_offset                                              392       12       12
> cmd_power                                               392       12       12
> cmd_sweep                                               388       28        9
> cmd_recall                                              352       20        8
> shellThread                                             296      140        5
...snip...
```

after:
```
...snip...
  4%        600 waThread2
  5%        832 waThread1
 11%       1616 measured
 11%       1616 trace_index
 14%       2048 spi_buffer
 32%       4552 current_props
total: 14005 bytes
sram:  14876/16384 (90%)
flash: 83384/131072 (63%)
```

static stack usage analysis from .su
```
$ ./avstack.pl build/obj/*.o | grep -E 'Thread1|cmd_|shellThread'
> Thread1                                                 616       28       13
> cmd_freq                                                400       20       12
> cmd_power                                               392       12       12
> cmd_offset                                              392       12       12
> cmd_sweep                                               388       28        9
> cmd_recall                                              352       20        8
> shellThread                                             296      140        5
...snip...
```