### PR TITLE
GCC8

### DIFF
--- a/adc.c
+++ b/adc.c
@@ -31,13 +31,26 @@ void adc_init(void)
 {
   rccEnableADC1(FALSE);
 
+  /* Ensure flag states */
+  ADC1->IER = 0;
+
   /* Calibration procedure.*/
   ADC->CCR = 0;
+  if (ADC1->CR & ADC_CR_ADEN) {
+      ADC1->CR |= ~ADC_CR_ADDIS; /* Disable ADC */
+  }
+  while (ADC1->CR & ADC_CR_ADEN)
+    ;
+  ADC1->CFGR1 &= ~ADC_CFGR1_DMAEN;
   ADC1->CR |= ADC_CR_ADCAL;
   while (ADC1->CR & ADC_CR_ADCAL)
     ;
 
-  ADC1->CR = ADC_CR_ADEN;
+  if (ADC1->ISR & ADC_ISR_ADRDY) {
+      ADC1->ISR |= ADC_ISR_ADRDY; /* clear ADRDY */
+  }
+  /* Enable ADC */
+  ADC1->CR |= ADC_CR_ADEN;
   while (!(ADC1->ISR & ADC_ISR_ADRDY))
     ;
 }


### PR DESCRIPTION
master でも GCC 8.2.1 でビルド可能ですが、adc_init まわりでなぜか stuck するようでした。コード的に間違いがありそうには見えないのですが、このパッチでうまく動くようになりました。manual の rev9 だと、サンプルコードで rev1 と比べて触るレジスタが増えていたので念のためコードをあわせるようにしました。

(homebew px4/px4 の gcc-arm-none-eabi-80 を使っています)

## gcc8   8.2.1 20181213 (release) [gcc-8-branch revision 267074]

```
sram:  14876/16384 (90%)
flash: 84924/131072 (64%)
```

static stack analysis
```
> Thread1                                                 572       28       13
  sweep                                                   544       76       12
  ui_process                                              468       60       11
> menu_marker_sel_cb                                      420       12        7
> cmd_freq                                                416       20       12
```

```
ch> info
Kernel:       4.0.0
Compiler:     GCC 8.2.1 20181213 (release) [gcc-8-branch revision 267074]
Architecture: ARMv6-M
Core Variant: Cortex-M0
Port Info:    Preemption through NMI
Platform:     STM32F072xB Entry Level Medium Density devices
Board:        NanoVNA
Build time:   Aug 30 2019 - 15:04:59
```

## gcc4  4.9.3 20150529 (release) [ARM/embedded-4_9-branch revision 227977]

```
sram:  14876/16384 (90%)
flash: 84240/131072 (64%)
```

static stack analysis
```
> Thread1                                                 592       28       13
  sweep                                                   564       76       12
  ui_process                                              488       60       11
> menu_marker_sel_cb                                      440       12        8
  redraw_marker                                           428       12        7
> menu_stimulus_cb                                        420       12       11
> menu_scale_cb                                           420       12       11
  draw_all_cells                                          416      188        6
> cmd_freq                                                416       20       12
```