### PR TITLE
[proposal] Time Domain Operation

### DIFF
--- a/fft.h
+++ b/fft.h
@@ -1,0 +1,78 @@
+/* 
+ * fft.h is Based on
+ * Free FFT and convolution (C)
+ * 
+ * Copyright (c) 2019 Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/free-small-fft-in-multiple-languages
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+
+#include <math.h>
+#include <stdint.h>
+
+static uint8_t reverse_bits(uint8_t x, int n) {
+	uint8_t result = 0;
+	for (int i = 0; i < n; i++, x >>= 1)
+		result = (result << 1) | (x & 1U);
+	return result;
+}
+
+/***
+ * dir = forward: 0, inverse: 1
+ */
+void fft(float array[][2], uint8_t n, uint8_t dir) {
+	int levels = 0;  // Compute levels = floor(log2(n))
+	for (uint8_t temp = n; temp > 1U; temp >>= 1)
+		levels++;
+
+	uint8_t real = dir & 1;
+	uint8_t imag = ~real & 1;
+
+	for (uint8_t i = 0; i < n; i++) {
+		uint8_t j = reverse_bits(i, levels);
+		if (j > i) {
+			float temp = array[i][real];
+			array[i][real] = array[j][real];
+			array[j][real] = temp;
+			temp = array[i][imag];
+			array[i][imag] = array[j][imag];
+			array[j][imag] = temp;
+		}
+	}
+
+	// Cooley-Tukey decimation-in-time radix-2 FFT
+	for (uint8_t size = 2; size <= n; size *= 2) {
+		uint8_t halfsize = size / 2;
+		uint8_t tablestep = n / size;
+		for (uint8_t i = 0; i < n; i += size) {
+			for (uint8_t j = i, k = 0; j < i + halfsize; j++, k += tablestep) {
+				uint8_t l = j + halfsize;
+				float tpre =  array[l][real] * cos(2 * M_PI * k / n) + array[l][imag] * sin(2 * M_PI * k / n);
+				float tpim = -array[l][real] * sin(2 * M_PI * k / n) + array[l][imag] * cos(2 * M_PI * k / n);
+				array[l][real] = array[j][real] - tpre;
+				array[l][imag] = array[j][imag] - tpim;
+				array[j][real] += tpre;
+				array[j][imag] += tpim;
+			}
+		}
+		if (size == n)  // Prevent overflow in 'size *= 2'
+			break;
+	}
+}
+

--- a/main.c
+++ b/main.c
@@ -547,6 +547,8 @@ properties_t current_props = {
     { 1, 30, 0 }, { 0, 40, 0 }, { 0, 60, 0 }, { 0, 80, 0 }
   },
   /* active_marker */      0,
+  /* domain_mode */        0,
+  /* velocity_factor */   70,
   /* checksum */           0
 };
 properties_t *active_props = &current_props;

--- a/main.c
+++ b/main.c
@@ -122,13 +122,13 @@ transform_domain(void)
           tmp[i*2+0] = 0.0;
           tmp[i*2+1] = 0.0;
       }
-      fft((float(*)[2])tmp, 128, 1);
+      fft128_inverse((float(*)[2])tmp);
       memcpy(measured[ch], tmp, sizeof(measured[0]));
       for (int i = 0; i < 101; i++) {
           measured[ch][i][0] /= 128.0;
           measured[ch][i][1] /= 128.0;
       }
-      if ( (domain_mode & TDR_FUNC_STEP) == TDR_FUNC_STEP ) {
+      if ( (domain_mode & TDR_FUNC) == TDR_FUNC_LOWPASS_STEP ) {
           for (int i = 1; i < 101; i++) {
               measured[ch][i][0] += measured[ch][i-1][0];
               measured[ch][i][1] += measured[ch][i-1][1];

--- a/main.c
+++ b/main.c
@@ -56,8 +56,6 @@ int8_t redraw_requested = FALSE;
 int8_t stop_the_world = FALSE;
 int16_t vbat = 0;
 
-uint8_t domain = DOMAIN_TIME;
-uint8_t tdrfunc = TDR_IMPULSE;
 static THD_WORKING_AREA(waThread1, 640);
 static THD_FUNCTION(Thread1, arg)
 {
@@ -116,7 +114,7 @@ static
 void
 transform_domain(void)
 {
-  if (domain != DOMAIN_TIME) return; // nothing to do for freq domain
+  if ((domain_mode & DOMAIN_MODE) != DOMAIN_TIME) return; // nothing to do for freq domain
   // use spi_buffer as temporary buffer
   // and calculate ifft for time domain
   float* tmp = (float*)spi_buffer;
@@ -132,7 +130,7 @@ transform_domain(void)
           measured[ch][i][0] /= 128.0;
           measured[ch][i][1] /= 128.0;
       }
-      if (tdrfunc == TDR_STEP) {
+      if ( (domain_mode & TDR_FUNC_STEP) == TDR_FUNC_STEP ) {
           for (int i = 1; i < 101; i++) {
               measured[ch][i][0] += measured[ch][i-1][0];
               measured[ch][i][1] += measured[ch][i-1][1];

--- a/main.c
+++ b/main.c
@@ -140,27 +140,27 @@ transform_domain(void)
   float* tmp = (float*)spi_buffer;
 
   uint8_t window_size, offset;
-  switch (domain_mode & TDR_FUNC) {
-      case TDR_FUNC_BANDPASS:
+  switch (domain_mode & TD_FUNC) {
+      case TD_FUNC_BANDPASS:
           offset = 0;
           window_size = 101;
           break;
-      case TDR_FUNC_LOWPASS_IMPULSE:
-      case TDR_FUNC_LOWPASS_STEP:
+      case TD_FUNC_LOWPASS_IMPULSE:
+      case TD_FUNC_LOWPASS_STEP:
           offset = 101;
           window_size = 202;
           break;
   }
 
   float beta = 0.0;
-  switch (domain_mode & TDR_WINDOW) {
-      case TDR_WINDOW_MINIMUM:
+  switch (domain_mode & TD_WINDOW) {
+      case TD_WINDOW_MINIMUM:
           beta = 0.0; // this is rectangular
           break;
-      case TDR_WINDOW_NORMAL:
+      case TD_WINDOW_NORMAL:
           beta = 6.0;
           break;
-      case TDR_WINDOW_MAXIMUM:
+      case TD_WINDOW_MAXIMUM:
           beta = 13;
           break;
   }
@@ -184,7 +184,7 @@ transform_domain(void)
           measured[ch][i][0] /= 128.0;
           measured[ch][i][1] /= 128.0;
       }
-      if ( (domain_mode & TDR_FUNC) == TDR_FUNC_LOWPASS_STEP ) {
+      if ( (domain_mode & TD_FUNC) == TD_FUNC_LOWPASS_STEP ) {
           for (int i = 1; i < 101; i++) {
               measured[ch][i][0] += measured[ch][i-1][0];
               measured[ch][i][1] += measured[ch][i-1][1];

--- a/nanovna.h
+++ b/nanovna.h
@@ -25,14 +25,6 @@
 
 extern float measured[2][101][2];
 
-enum {
-  DOMAIN_FREQ, DOMAIN_TIME
-};
-
-enum {
-  TDR_IMPULSE, TDR_STEP
-};
-
 #define CAL_LOAD 0
 #define CAL_OPEN 1
 #define CAL_SHORT 2
@@ -61,14 +53,14 @@ enum {
 #define DOMAIN_MODE (1<<0)
 #define DOMAIN_FREQ (0<<0)
 #define DOMAIN_TIME (1<<0)
-#define TDR_FUNC (0b11<<1)
-#define TDR_FUNC_BANDPASS (0b00<<1)
-#define TDR_FUNC_LOWPASS_IMPULSE (0b01<<1)
-#define TDR_FUNC_LOWPASS_STEP    (0b10<<1)
-#define TDR_WINDOW (0b11<<3)
-#define TDR_WINDOW_NORMAL (0b00<<3)
-#define TDR_WINDOW_MINIMUM (0b01<<3)
-#define TDR_WINDOW_MAXIMUM (0b10<<3)
+#define TD_FUNC (0b11<<1)
+#define TD_FUNC_BANDPASS (0b00<<1)
+#define TD_FUNC_LOWPASS_IMPULSE (0b01<<1)
+#define TD_FUNC_LOWPASS_STEP    (0b10<<1)
+#define TD_WINDOW (0b11<<3)
+#define TD_WINDOW_NORMAL (0b00<<3)
+#define TD_WINDOW_MINIMUM (0b01<<3)
+#define TD_WINDOW_MAXIMUM (0b10<<3)
 
 void cal_collect(int type);
 void cal_done(void);
@@ -303,7 +295,7 @@ typedef struct {
   trace_t _trace[TRACES_MAX];
   marker_t _markers[4];
   int _active_marker;
-  uint8_t _domain_mode; /* 0bxxxxxffm : where ff: TDR_FUNC m: DOMAIN_MODE */
+  uint8_t _domain_mode; /* 0bxxxxxffm : where ff: TD_FUNC m: DOMAIN_MODE */
   uint8_t _velocity_factor; // %
 
   int32_t checksum;

--- a/nanovna.h
+++ b/nanovna.h
@@ -33,9 +33,6 @@ enum {
   TDR_IMPULSE, TDR_STEP
 };
 
-extern uint8_t domain;
-extern uint8_t tdrfunc;
-
 #define CAL_LOAD 0
 #define CAL_OPEN 1
 #define CAL_SHORT 2
@@ -60,6 +57,13 @@ extern uint8_t tdrfunc;
 #define ETERM_ER 2 /* error term refrection tracking */
 #define ETERM_ET 3 /* error term transmission tracking */
 #define ETERM_EX 4 /* error term isolation */
+
+#define DOMAIN_MODE (1<<0)
+#define DOMAIN_FREQ (0<<0)
+#define DOMAIN_TIME (1<<0)
+#define TDR_FUNC (1<<1)
+#define TDR_FUNC_IMPULSE (0<<1)
+#define TDR_FUNC_STEP    (1<<1)
 
 void cal_collect(int type);
 void cal_done(void);
@@ -294,6 +298,7 @@ typedef struct {
   trace_t _trace[TRACES_MAX];
   marker_t _markers[4];
   int _active_marker;
+  uint8_t _domain_mode;
 
   int32_t checksum;
 } properties_t;
@@ -317,6 +322,7 @@ extern int8_t previous_marker;
 #define trace current_props._trace
 #define markers current_props._markers
 #define active_marker current_props._active_marker
+#define domain_mode current_props._domain_mode
 
 int caldata_save(int id);
 int caldata_recall(int id);

--- a/nanovna.h
+++ b/nanovna.h
@@ -299,6 +299,7 @@ typedef struct {
   marker_t _markers[4];
   int _active_marker;
   uint8_t _domain_mode;
+  uint8_t _velocity_factor; // %
 
   int32_t checksum;
 } properties_t;
@@ -323,6 +324,7 @@ extern int8_t previous_marker;
 #define markers current_props._markers
 #define active_marker current_props._active_marker
 #define domain_mode current_props._domain_mode
+#define velocity_factor current_props._velocity_factor
 
 int caldata_save(int id);
 int caldata_recall(int id);

--- a/nanovna.h
+++ b/nanovna.h
@@ -22,7 +22,19 @@
 /*
  * main.c
  */
+
 extern float measured[2][101][2];
+
+enum {
+  DOMAIN_FREQ, DOMAIN_TIME
+};
+
+enum {
+  TDR_IMPULSE, TDR_STEP
+};
+
+extern uint8_t domain;
+extern uint8_t tdrfunc;
 
 #define CAL_LOAD 0
 #define CAL_OPEN 1

--- a/nanovna.h
+++ b/nanovna.h
@@ -61,9 +61,14 @@ enum {
 #define DOMAIN_MODE (1<<0)
 #define DOMAIN_FREQ (0<<0)
 #define DOMAIN_TIME (1<<0)
-#define TDR_FUNC (1<<1)
-#define TDR_FUNC_IMPULSE (0<<1)
-#define TDR_FUNC_STEP    (1<<1)
+#define TDR_FUNC (0b11<<1)
+#define TDR_FUNC_BANDPASS (0b00<<1)
+#define TDR_FUNC_LOWPASS_IMPULSE (0b01<<1)
+#define TDR_FUNC_LOWPASS_STEP    (0b10<<1)
+#define TDR_WINDOW (0b11<<3)
+#define TDR_WINDOW_NORMAL (0b00<<3)
+#define TDR_WINDOW_MINIMUM (0b01<<3)
+#define TDR_WINDOW_MAXIMUM (0b10<<3)
 
 void cal_collect(int type);
 void cal_done(void);
@@ -298,7 +303,7 @@ typedef struct {
   trace_t _trace[TRACES_MAX];
   marker_t _markers[4];
   int _active_marker;
-  uint8_t _domain_mode;
+  uint8_t _domain_mode; /* 0bxxxxxffm : where ff: TDR_FUNC m: DOMAIN_MODE */
   uint8_t _velocity_factor; // %
 
   int32_t checksum;

--- a/plot.c
+++ b/plot.c
@@ -1367,8 +1367,15 @@ cell_draw_marker_info(int m, int n, int w, int h)
   chsnprintf(buf, sizeof buf, "%d:", active_marker + 1);
   cell_drawstring_5x7(w, h, buf, xpos, ypos, 0xffff);
   xpos += 16;
-  frequency_string(buf, sizeof buf, frequencies[idx]);
-  cell_drawstring_5x7(w, h, buf, xpos, ypos, 0xffff);
+  if (domain == DOMAIN_FREQ) {
+      frequency_string(buf, sizeof buf, frequencies[idx]);
+      cell_drawstring_5x7(w, h, buf, xpos, ypos, 0xffff);
+  } else {
+#define SPEED_OF_LIGHT 299792458
+      float distance = ((float)idx * (float)SPEED_OF_LIGHT) / ( (float)(frequencies[1] - frequencies[0]) * 128.0 * 2.0);
+      chsnprintf(buf, sizeof buf, "%f m", distance);
+      cell_drawstring_5x7(w, h, buf, xpos, ypos, 0xffff);
+  }
 
   // draw marker delta
   if (previous_marker >= 0 && active_marker != previous_marker && markers[previous_marker].enabled) {

--- a/plot.c
+++ b/plot.c
@@ -1367,7 +1367,7 @@ cell_draw_marker_info(int m, int n, int w, int h)
   chsnprintf(buf, sizeof buf, "%d:", active_marker + 1);
   cell_drawstring_5x7(w, h, buf, xpos, ypos, 0xffff);
   xpos += 16;
-  if (domain == DOMAIN_FREQ) {
+  if ((domain_mode & DOMAIN_MODE) == DOMAIN_FREQ) {
       frequency_string(buf, sizeof buf, frequencies[idx]);
       cell_drawstring_5x7(w, h, buf, xpos, ypos, 0xffff);
   } else {

--- a/plot.c
+++ b/plot.c
@@ -1373,7 +1373,7 @@ cell_draw_marker_info(int m, int n, int w, int h)
   } else {
 #define SPEED_OF_LIGHT 299792458
       float distance = ((float)idx * (float)SPEED_OF_LIGHT) / ( (float)(frequencies[1] - frequencies[0]) * 128.0 * 2.0);
-      chsnprintf(buf, sizeof buf, "%f m", distance);
+      chsnprintf(buf, sizeof buf, "%.1f m (%d%%)", distance * (velocity_factor / 100.0), velocity_factor);
       cell_drawstring_5x7(w, h, buf, xpos, ypos, 0xffff);
   }
 

--- a/plot.c
+++ b/plot.c
@@ -701,11 +701,16 @@ trace_get_info(int t, char *buf, int len)
   }
 }
 
+static float time_of_index(int idx) {
+   return 1.0 / (float)(frequencies[1] - frequencies[0]) / 128.0 * idx;
+}
+
 static float distance_of_index(int idx) {
 #define SPEED_OF_LIGHT 299792458
    float distance = ((float)idx * (float)SPEED_OF_LIGHT) / ( (float)(frequencies[1] - frequencies[0]) * 128.0 * 2.0);
    return distance * (velocity_factor / 100.0);
 }
+
 
 static inline void
 mark_map(int x, int y)
@@ -1377,7 +1382,7 @@ cell_draw_marker_info(int m, int n, int w, int h)
       frequency_string(buf, sizeof buf, frequencies[idx]);
       cell_drawstring_5x7(w, h, buf, xpos, ypos, 0xffff);
   } else {
-      chsnprintf(buf, sizeof buf, "%.1f m (VF=%d%%)", distance_of_index(idx), velocity_factor);
+      chsnprintf(buf, sizeof buf, "%d ns %.1f m", (uint16_t)(time_of_index(idx) * 1e9), distance_of_index(idx));
       cell_drawstring_5x7(w, h, buf, xpos, ypos, 0xffff);
   }
 
@@ -1421,37 +1426,47 @@ void
 draw_frequencies(void)
 {
   char buf[24];
-  if (frequency1 > 0) {
-    int start = frequency0;
-    int stop = frequency1;
-    strcpy(buf, "START ");
-    frequency_string(buf+6, 24-6, start);
-    strcat(buf, "    ");
-    ili9341_drawstring_5x7(buf, OFFSETX, 233, 0xffff, 0x0000);
-    strcpy(buf, "STOP ");
-    frequency_string(buf+5, 24-5, stop);
-    strcat(buf, "    ");
-    ili9341_drawstring_5x7(buf, 205, 233, 0xffff, 0x0000);
-  } else if (frequency1 < 0) {
-    int fcenter = frequency0;
-    int fspan = -frequency1;
-    strcpy(buf, "CENTER ");
-    frequency_string(buf+7, 24-7, fcenter);
-    strcat(buf, "    ");
-    ili9341_drawstring_5x7(buf, OFFSETX, 233, 0xffff, 0x0000);
-    strcpy(buf, "SPAN ");
-    frequency_string(buf+5, 24-5, fspan);
-    strcat(buf, "    ");
-    ili9341_drawstring_5x7(buf, 205, 233, 0xffff, 0x0000);
+  if ((domain_mode & DOMAIN_MODE) == DOMAIN_FREQ) {
+      if (frequency1 > 0) {
+        int start = frequency0;
+        int stop = frequency1;
+        strcpy(buf, "START ");
+        frequency_string(buf+6, 24-6, start);
+        strcat(buf, "    ");
+        ili9341_drawstring_5x7(buf, OFFSETX, 233, 0xffff, 0x0000);
+        strcpy(buf, "STOP ");
+        frequency_string(buf+5, 24-5, stop);
+        strcat(buf, "    ");
+        ili9341_drawstring_5x7(buf, 205, 233, 0xffff, 0x0000);
+      } else if (frequency1 < 0) {
+        int fcenter = frequency0;
+        int fspan = -frequency1;
+        strcpy(buf, "CENTER ");
+        frequency_string(buf+7, 24-7, fcenter);
+        strcat(buf, "    ");
+        ili9341_drawstring_5x7(buf, OFFSETX, 233, 0xffff, 0x0000);
+        strcpy(buf, "SPAN ");
+        frequency_string(buf+5, 24-5, fspan);
+        strcat(buf, "    ");
+        ili9341_drawstring_5x7(buf, 205, 233, 0xffff, 0x0000);
+      } else {
+        int fcenter = frequency0;
+        chsnprintf(buf, 24, "CW %d.%03d %03d MHz    ",
+                   (int)(fcenter / 1000000),
+                   (int)((fcenter / 1000) % 1000),
+                   (int)(fcenter % 1000));
+        ili9341_drawstring_5x7(buf, OFFSETX, 233, 0xffff, 0x0000);
+        chsnprintf(buf, 24, "                             ");
+        ili9341_drawstring_5x7(buf, 205, 233, 0xffff, 0x0000);
+      }
   } else {
-    int fcenter = frequency0;
-    chsnprintf(buf, 24, "CW %d.%03d %03d MHz    ",
-               (int)(fcenter / 1000000),
-               (int)((fcenter / 1000) % 1000),
-               (int)(fcenter % 1000));
-    ili9341_drawstring_5x7(buf, OFFSETX, 233, 0xffff, 0x0000);
-    chsnprintf(buf, 24, "                             ");
-    ili9341_drawstring_5x7(buf, 205, 233, 0xffff, 0x0000);
+      strcpy(buf, "START 0s        ");
+      ili9341_drawstring_5x7(buf, OFFSETX, 233, 0xffff, 0x0000);
+
+      strcpy(buf, "STOP ");
+      chsnprintf(buf+5, 24-5, "%d ns", (uint16_t)(time_of_index(101) * 1e9));
+      strcat(buf, "          ");
+      ili9341_drawstring_5x7(buf, 205, 233, 0xffff, 0x0000);
   }
 }
 

--- a/plot.c
+++ b/plot.c
@@ -701,6 +701,12 @@ trace_get_info(int t, char *buf, int len)
   }
 }
 
+static float distance_of_index(int idx) {
+#define SPEED_OF_LIGHT 299792458
+   float distance = ((float)idx * (float)SPEED_OF_LIGHT) / ( (float)(frequencies[1] - frequencies[0]) * 128.0 * 2.0);
+   return distance * (velocity_factor / 100.0);
+}
+
 static inline void
 mark_map(int x, int y)
 {
@@ -1371,9 +1377,7 @@ cell_draw_marker_info(int m, int n, int w, int h)
       frequency_string(buf, sizeof buf, frequencies[idx]);
       cell_drawstring_5x7(w, h, buf, xpos, ypos, 0xffff);
   } else {
-#define SPEED_OF_LIGHT 299792458
-      float distance = ((float)idx * (float)SPEED_OF_LIGHT) / ( (float)(frequencies[1] - frequencies[0]) * 128.0 * 2.0);
-      chsnprintf(buf, sizeof buf, "%.1f m (%d%%)", distance * (velocity_factor / 100.0), velocity_factor);
+      chsnprintf(buf, sizeof buf, "%.1f m (VF=%d%%)", distance_of_index(idx), velocity_factor);
       cell_drawstring_5x7(w, h, buf, xpos, ypos, 0xffff);
   }
 

--- a/ui.c
+++ b/ui.c
@@ -670,15 +670,15 @@ menu_transform_window_cb(int item)
   // TODO
   switch (item) {
     case 0:
-      domain_mode = (domain_mode & ~TDR_WINDOW) | TDR_WINDOW_MINIMUM;
+      domain_mode = (domain_mode & ~TD_WINDOW) | TD_WINDOW_MINIMUM;
       ui_mode_normal();
       break;
     case 1:
-      domain_mode = (domain_mode & ~TDR_WINDOW) | TDR_WINDOW_NORMAL;
+      domain_mode = (domain_mode & ~TD_WINDOW) | TD_WINDOW_NORMAL;
       ui_mode_normal();
       break;
     case 2:
-      domain_mode = (domain_mode & ~TDR_WINDOW) | TDR_WINDOW_MAXIMUM;
+      domain_mode = (domain_mode & ~TD_WINDOW) | TD_WINDOW_MAXIMUM;
       ui_mode_normal();
       break;
   }
@@ -699,15 +699,15 @@ menu_transform_cb(int item)
       ui_mode_normal();
       break;
     case 1:
-      domain_mode = (domain_mode & ~TDR_FUNC) | TDR_FUNC_LOWPASS_IMPULSE;
+      domain_mode = (domain_mode & ~TD_FUNC) | TD_FUNC_LOWPASS_IMPULSE;
       ui_mode_normal();
       break;
     case 2:
-      domain_mode = (domain_mode & ~TDR_FUNC) | TDR_FUNC_LOWPASS_STEP;
+      domain_mode = (domain_mode & ~TD_FUNC) | TD_FUNC_LOWPASS_STEP;
       ui_mode_normal();
       break;
     case 3:
-      domain_mode = (domain_mode & ~TDR_FUNC) | TDR_FUNC_BANDPASS;
+      domain_mode = (domain_mode & ~TD_FUNC) | TD_FUNC_BANDPASS;
       ui_mode_normal();
       break;
     case 5:
@@ -1318,17 +1318,17 @@ menu_item_modify_attribute(const menuitem_t *menu, int item,
     }
   } else if (menu == menu_transform) {
       if ((item == 0 && (domain_mode & DOMAIN_MODE) == DOMAIN_TIME)
-       || (item == 1 && (domain_mode & TDR_FUNC) == TDR_FUNC_LOWPASS_IMPULSE)
-       || (item == 2 && (domain_mode & TDR_FUNC) == TDR_FUNC_LOWPASS_STEP)
-       || (item == 3 && (domain_mode & TDR_FUNC) == TDR_FUNC_BANDPASS)
+       || (item == 1 && (domain_mode & TD_FUNC) == TD_FUNC_LOWPASS_IMPULSE)
+       || (item == 2 && (domain_mode & TD_FUNC) == TD_FUNC_LOWPASS_STEP)
+       || (item == 3 && (domain_mode & TD_FUNC) == TD_FUNC_BANDPASS)
        ) {
         *bg = 0x0000;
         *fg = 0xffff;
       }
   } else if (menu == menu_transform_window) {
-      if ((item == 0 && (domain_mode & TDR_WINDOW) == TDR_WINDOW_MINIMUM)
-       || (item == 1 && (domain_mode & TDR_WINDOW) == TDR_WINDOW_NORMAL)
-       || (item == 2 && (domain_mode & TDR_WINDOW) == TDR_WINDOW_MAXIMUM)
+      if ((item == 0 && (domain_mode & TD_WINDOW) == TD_WINDOW_MINIMUM)
+       || (item == 1 && (domain_mode & TD_WINDOW) == TD_WINDOW_NORMAL)
+       || (item == 2 && (domain_mode & TD_WINDOW) == TD_WINDOW_MAXIMUM)
        ) {
         *bg = 0x0000;
         *fg = 0xffff;

--- a/ui.c
+++ b/ui.c
@@ -669,13 +669,17 @@ menu_tdr_cb(int item)
 {
   switch (item) {
     case 0:
-      domain = (domain == DOMAIN_FREQ) ? DOMAIN_TIME : DOMAIN_FREQ;
+        if ((domain_mode & DOMAIN_MODE) == DOMAIN_TIME) {
+            domain_mode = (domain_mode & ~DOMAIN_MODE) | DOMAIN_FREQ;
+        } else {
+            domain_mode = (domain_mode & ~DOMAIN_MODE) | DOMAIN_TIME;
+        }
       break;
     case 1:
-      tdrfunc = TDR_IMPULSE;
+      domain_mode = (domain_mode & ~TDR_FUNC) | TDR_FUNC_IMPULSE;
       break;
     case 2:
-      tdrfunc = TDR_STEP;
+      domain_mode = (domain_mode & ~TDR_FUNC) | TDR_FUNC_STEP;
       break;
   }
 
@@ -1249,6 +1253,7 @@ menu_item_modify_attribute(const menuitem_t *menu, int item,
         || (item == 2 && (cal_status & CALSTAT_LOAD))
         || (item == 3 && (cal_status & CALSTAT_ISOLN))
         || (item == 4 && (cal_status & CALSTAT_THRU))) {
+      domain_mode = (domain_mode & ~DOMAIN_MODE) | DOMAIN_FREQ;
       *bg = 0x0000;
       *fg = 0xffff;
     }
@@ -1263,9 +1268,9 @@ menu_item_modify_attribute(const menuitem_t *menu, int item,
       *fg = 0xffff;
     }
   } else if (menu == menu_tdr) {
-      if ((item == 0 && domain == DOMAIN_TIME)
-       || (item == 1 && tdrfunc == TDR_IMPULSE)
-       || (item == 2 && tdrfunc == TDR_STEP)
+      if ((item == 0 && (domain_mode & DOMAIN_MODE) == DOMAIN_TIME)
+       || (item == 1 && (domain_mode & TDR_FUNC) == TDR_FUNC_IMPULSE)
+       || (item == 2 && (domain_mode & TDR_FUNC) == TDR_FUNC_STEP)
        ) {
         *bg = 0x0000;
         *fg = 0xffff;

--- a/ui.c
+++ b/ui.c
@@ -664,6 +664,24 @@ menu_channel_cb(int item)
   ui_mode_normal();
 }
 
+static void
+menu_tdr_cb(int item)
+{
+  switch (item) {
+    case 0:
+      domain = (domain == DOMAIN_FREQ) ? DOMAIN_TIME : DOMAIN_FREQ;
+      break;
+    case 1:
+      tdrfunc = TDR_IMPULSE;
+      break;
+    case 2:
+      tdrfunc = TDR_STEP;
+      break;
+  }
+
+  ui_mode_normal();
+}
+
 static void 
 choose_active_marker(void)
 {
@@ -874,11 +892,20 @@ const menuitem_t menu_channel[] = {
   { MT_NONE, NULL, NULL } // sentinel
 };
 
+const menuitem_t menu_tdr[] = {
+  { MT_CALLBACK, "TDR MODE", menu_tdr_cb },
+  { MT_CALLBACK, "IMPULSE", menu_tdr_cb },
+  { MT_CALLBACK, "STEP", menu_tdr_cb },
+  { MT_CANCEL, S_LARROW" BACK", NULL },
+  { MT_NONE, NULL, NULL } // sentinel
+};
+
 const menuitem_t menu_display[] = {
   { MT_SUBMENU, "TRACE", menu_trace },
   { MT_SUBMENU, "FORMAT", menu_format },
   { MT_SUBMENU, "SCALE", menu_scale },
   { MT_SUBMENU, "CHANNEL", menu_channel },
+  { MT_SUBMENU, "TDR", menu_tdr },
   { MT_CANCEL, S_LARROW" BACK", NULL },
   { MT_NONE, NULL, NULL } // sentinel
 };
@@ -1235,6 +1262,14 @@ menu_item_modify_attribute(const menuitem_t *menu, int item,
       *bg = 0x0000;
       *fg = 0xffff;
     }
+  } else if (menu == menu_tdr) {
+      if ((item == 0 && domain == DOMAIN_TIME)
+       || (item == 1 && tdrfunc == TDR_IMPULSE)
+       || (item == 2 && tdrfunc == TDR_STEP)
+       ) {
+        *bg = 0x0000;
+        *fg = 0xffff;
+      }
   }
 }
 

--- a/ui.c
+++ b/ui.c
@@ -665,7 +665,27 @@ menu_channel_cb(int item)
 }
 
 static void
-menu_tdr_cb(int item)
+menu_transform_window_cb(int item)
+{
+  // TODO
+  switch (item) {
+    case 0:
+      domain_mode = (domain_mode & ~TDR_WINDOW) | TDR_WINDOW_MINIMUM;
+      ui_mode_normal();
+      break;
+    case 1:
+      domain_mode = (domain_mode & ~TDR_WINDOW) | TDR_WINDOW_NORMAL;
+      ui_mode_normal();
+      break;
+    case 2:
+      domain_mode = (domain_mode & ~TDR_WINDOW) | TDR_WINDOW_MAXIMUM;
+      ui_mode_normal();
+      break;
+  }
+}
+
+static void
+menu_transform_cb(int item)
 {
   int status;
   switch (item) {
@@ -678,14 +698,18 @@ menu_tdr_cb(int item)
       ui_mode_normal();
       break;
     case 1:
-      domain_mode = (domain_mode & ~TDR_FUNC) | TDR_FUNC_IMPULSE;
+      domain_mode = (domain_mode & ~TDR_FUNC) | TDR_FUNC_LOWPASS_IMPULSE;
       ui_mode_normal();
       break;
     case 2:
-      domain_mode = (domain_mode & ~TDR_FUNC) | TDR_FUNC_STEP;
+      domain_mode = (domain_mode & ~TDR_FUNC) | TDR_FUNC_LOWPASS_STEP;
       ui_mode_normal();
       break;
     case 3:
+      domain_mode = (domain_mode & ~TDR_FUNC) | TDR_FUNC_BANDPASS;
+      ui_mode_normal();
+      break;
+    case 5:
       status = btn_wait_release();
       if (status & EVT_BUTTON_DOWN_LONG) {
         ui_mode_numeric(KM_VELOCITY_FACTOR);
@@ -908,11 +932,21 @@ const menuitem_t menu_channel[] = {
   { MT_NONE, NULL, NULL } // sentinel
 };
 
-const menuitem_t menu_tdr[] = {
-  { MT_CALLBACK, "TDR MODE", menu_tdr_cb },
-  { MT_CALLBACK, "IMPULSE", menu_tdr_cb },
-  { MT_CALLBACK, "STEP", menu_tdr_cb },
-  { MT_CALLBACK, "\2VELOCITY\0FACTOR", menu_tdr_cb },
+const menuitem_t menu_transform_window[] = {
+  { MT_CALLBACK, "MINIMUM", menu_transform_window_cb },
+  { MT_CALLBACK, "NORMAL", menu_transform_window_cb },
+  { MT_CALLBACK, "MAXIMUM", menu_transform_window_cb },
+  { MT_CANCEL, S_LARROW" BACK", NULL },
+  { MT_NONE, NULL, NULL } // sentinel
+};
+
+const menuitem_t menu_transform[] = {
+  { MT_CALLBACK, "\2TRANSFORM\0ON", menu_transform_cb },
+  { MT_CALLBACK, "\2LOW PASS\0IMPULSE", menu_transform_cb },
+  { MT_CALLBACK, "\2LOW PASS\0STEP", menu_transform_cb },
+  { MT_CALLBACK, "BANDPASS", menu_transform_cb },
+  { MT_SUBMENU, "WINDOW", menu_transform_window },
+  { MT_CALLBACK, "\2VELOCITY\0FACTOR", menu_transform_cb },
   { MT_CANCEL, S_LARROW" BACK", NULL },
   { MT_NONE, NULL, NULL } // sentinel
 };
@@ -922,7 +956,7 @@ const menuitem_t menu_display[] = {
   { MT_SUBMENU, "FORMAT", menu_format },
   { MT_SUBMENU, "SCALE", menu_scale },
   { MT_SUBMENU, "CHANNEL", menu_channel },
-  { MT_SUBMENU, "TDR", menu_tdr },
+  { MT_SUBMENU, "TRANSFORM", menu_transform },
   { MT_CANCEL, S_LARROW" BACK", NULL },
   { MT_NONE, NULL, NULL } // sentinel
 };
@@ -1168,7 +1202,7 @@ const keypads_t * const keypads_mode_tbl[] = {
 };
 
 const char * const keypad_mode_label[] = {
-  "START", "STOP", "CENTER", "SPAN", "CW FREQ", "SCALE", "REFPOS", "EDELAY", "VELOCITY"
+  "START", "STOP", "CENTER", "SPAN", "CW FREQ", "SCALE", "REFPOS", "EDELAY", "VELOCITY%"
 };
 
 void
@@ -1281,10 +1315,19 @@ menu_item_modify_attribute(const menuitem_t *menu, int item,
       *bg = 0x0000;
       *fg = 0xffff;
     }
-  } else if (menu == menu_tdr) {
+  } else if (menu == menu_transform) {
       if ((item == 0 && (domain_mode & DOMAIN_MODE) == DOMAIN_TIME)
-       || (item == 1 && (domain_mode & TDR_FUNC) == TDR_FUNC_IMPULSE)
-       || (item == 2 && (domain_mode & TDR_FUNC) == TDR_FUNC_STEP)
+       || (item == 1 && (domain_mode & TDR_FUNC) == TDR_FUNC_LOWPASS_IMPULSE)
+       || (item == 2 && (domain_mode & TDR_FUNC) == TDR_FUNC_LOWPASS_STEP)
+       || (item == 3 && (domain_mode & TDR_FUNC) == TDR_FUNC_BANDPASS)
+       ) {
+        *bg = 0x0000;
+        *fg = 0xffff;
+      }
+  } else if (menu == menu_transform_window) {
+      if ((item == 0 && (domain_mode & TDR_WINDOW) == TDR_WINDOW_MINIMUM)
+       || (item == 1 && (domain_mode & TDR_WINDOW) == TDR_WINDOW_NORMAL)
+       || (item == 2 && (domain_mode & TDR_WINDOW) == TDR_WINDOW_MAXIMUM)
        ) {
         *bg = 0x0000;
         *fg = 0xffff;

--- a/ui.c
+++ b/ui.c
@@ -695,6 +695,7 @@ menu_transform_cb(int item)
       } else {
           domain_mode = (domain_mode & ~DOMAIN_MODE) | DOMAIN_TIME;
       }
+      draw_frequencies();
       ui_mode_normal();
       break;
     case 1:


### PR DESCRIPTION
![nanovna (21)](https://user-images.githubusercontent.com/3092/64702236-20899e80-d4e5-11e9-84f8-0953ebbdd4d9.png)
![nanovna (26)](https://user-images.githubusercontent.com/3092/64702468-94c44200-d4e5-11e9-8b8f-b0514f6c62c5.png)
![nanovna (27)](https://user-images.githubusercontent.com/3092/64703384-40ba5d00-d4e7-11e9-8185-5b9ad582d97b.png)


完璧ではないかもですが、time domain で値を見れるようにしてみました。メニューは HP8753 を参考にしたつもりです (実機はよく知らないためマニュアル参照ですが)

実装方針

 * 101 の measured を 128point で ifft。ただし計算後は 101 points に切り詰めて、measured に戻す。
 * グラフ描画自体は既存のロジックのまま (ドメインの変換だけしている)
 * 一時計算用に spi_buffer を再利用している。

わかっているものの対処していない問題

 * measured を書きかえているので、USB 経由で data をとると ifft 済みのものがとれてしまう
   (measured をドメイン別に保持するのはメモリ的に無理ではないかと思っています)
 * ui 操作で sweep を break した場合、measured が中途半端な値で ifft するためグラフが乱れる (もう1サイクルsweepを待てばなおりますが工夫がいりそう)
