### PR TITLE
Fixed tar extract command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install cross tools and firmware updating tool.
 Download arm cross tools from [here](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads).
 
     $ wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2
-    $ sudo tar xfj -C /usr/local gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2
+    $ sudo tar xfj gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2 -C /usr/local
     $ PATH=/usr/local/gcc-arm-none-eabi-8-2018-q4-major/bin:$PATH
     $ sudo apt install -y dfu-util
 


### PR DESCRIPTION
The tar command did not worked in my Ubuntu 18.04. Don't know if it is wrong in the documentation from the beginning or if something changed in tar.