### PR TITLE
Bugfix: disabling all the markers causes the GUI to freeze

### DIFF
--- a/plot.c
+++ b/plot.c
@@ -1493,6 +1493,8 @@ draw_all(bool flush)
 void
 redraw_marker(int marker, int update_info)
 {
+  if (marker < 0)
+    return;
   // mark map on new position of marker
   markmap_marker(marker);
 


### PR DESCRIPTION
There was a missing check on the current_marker index, it was used even if it was invalid (-1)