### PR TITLE
Issue79

### DIFF
--- a/ui.c
+++ b/ui.c
@@ -2105,10 +2105,10 @@ ui_process_keypad(void)
       if (key >= 0 && keypad_click(key))
         /* exit loop on done or cancel */
         break;
-      else if (key == -2) {
-        //xxx;
-        return;
-      }
+//      else if (key == -2) {
+//        //xxx;
+//        return;
+//      }
     }
   }
 


### PR DESCRIPTION
There is a return from ui_process_keypad without a clean ui_mode switch. I've seen that this happen in the special case when the touch_y > 48 * 4:  probably the original intention was to switch from UI_KEYPAD to UI_NUMERIC whenever the user touch the numeric area. (the bottom part of the screen).

For the moment I commented out the part of the code causing the problem.