### PR TITLE
Do not draw battery icon if D2 is not present

### DIFF
--- a/main.c
+++ b/main.c
@@ -83,7 +83,9 @@ static THD_FUNCTION(Thread1, arg)
           adc_stop(ADC1);
           vbat = adc_vbat_read(ADC1);
           touch_start_watchdog();
-          draw_battery_status();
+          if (vbat != -1) {
+            draw_battery_status();
+          }
         }
 
         /* calculate trace coordinates and plot only if scan completed */


### PR DESCRIPTION
We need to check `vbat` again after the voltage is read the first time,
otherwise an empty battery icon will be drawn once and it will persist
until the screen is fully redrawn.