### PR TITLE
Speedup and fix Si5351 clock generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,13 +64,13 @@ endif
 # Stack size to be allocated to the Cortex-M process stack. This stack is
 # the stack used by the main() thread.
 ifeq ($(USE_PROCESS_STACKSIZE),)
-  USE_PROCESS_STACKSIZE = 0x200
+  USE_PROCESS_STACKSIZE = 0x300
 endif
 
 # Stack size to the allocated to the Cortex-M main/exceptions stack. This
 # stack is used for processing interrupts and exceptions.
 ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
-  USE_EXCEPTIONS_STACKSIZE = 0x200
+  USE_EXCEPTIONS_STACKSIZE = 0x100
 endif
 
 #

--- a/Makefile
+++ b/Makefile
@@ -64,13 +64,13 @@ endif
 # Stack size to be allocated to the Cortex-M process stack. This stack is
 # the stack used by the main() thread.
 ifeq ($(USE_PROCESS_STACKSIZE),)
-  USE_PROCESS_STACKSIZE = 0x300
+  USE_PROCESS_STACKSIZE = 0x200
 endif
 
 # Stack size to the allocated to the Cortex-M main/exceptions stack. This
 # stack is used for processing interrupts and exceptions.
 ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
-  USE_EXCEPTIONS_STACKSIZE = 0x100
+  USE_EXCEPTIONS_STACKSIZE = 0x200
 endif
 
 #

--- a/main.c
+++ b/main.c
@@ -58,6 +58,7 @@ static char shell_line[VNA_SHELL_MAX_LENGTH];
 //#define ENABLE_THREADS_COMMAND
 //#define ENABLE_TIME_COMMAND
 #define ENABLE_VBAT_OFFSET_COMMAND
+#define ENABLE_INFO_COMMAND
 
 static void apply_error_term_at(int i);
 static void apply_edelay_at(int i);
@@ -81,6 +82,21 @@ static uint32_t frequency = 10000000;
 static int8_t drive_strength = DRIVE_STRENGTH_AUTO;
 int8_t sweep_mode = SWEEP_ENABLE;
 volatile uint8_t redraw_request = 0; // contains REDRAW_XXX flags
+
+// Version text, displayed in Config->Version menu, also send by info command
+const char *info_about[]={
+  BOARD_NAME,
+  "2016-2020 Copyright @edy555",
+  "Licensed under GPL. See: https://github.com/ttrftech/NanoVNA",
+  "Version: " VERSION,
+  "Build Time: " __DATE__ " - " __TIME__,
+  "Kernel: " CH_KERNEL_VERSION,
+  "Compiler: " PORT_COMPILER_NAME,
+  "Architecture: " PORT_ARCHITECTURE_NAME " Core Variant: " PORT_CORE_VARIANT_NAME,
+  "Port Info: " PORT_INFO,
+  "Platform: " PLATFORM_NAME,
+  0 // sentinel
+};
 
 static THD_WORKING_AREA(waThread1, 640);
 static THD_FUNCTION(Thread1, arg)
@@ -1949,6 +1965,17 @@ VNA_SHELL_FUNCTION(cmd_vbat_offset)
 }
 #endif
 
+#ifdef ENABLE_INFO_COMMAND
+VNA_SHELL_FUNCTION(cmd_info)
+{
+  (void)argc;
+  (void)argv;
+  int i=0;
+  while (info_about[i])
+    shell_printf("%s\r\n", info_about[i++]);
+}
+#endif
+
 #ifdef ENABLE_THREADS_COMMAND
 #if CH_CFG_USE_REGISTRY == FALSE
 #error "Threads Requite enabled CH_CFG_USE_REGISTRY in chconf.h"
@@ -1970,8 +1997,6 @@ VNA_SHELL_FUNCTION(cmd_threads) {
 #else
     uint32_t stklimit = 0U;
 #endif
-
-
     shell_printf("%08x|%08x|%08x|%08x|%4u|%4u|%9s|%12s"VNA_SHELL_NEWLINE_STR,
              stklimit, (uint32_t)tp->ctx.sp, max_stack_use, (uint32_t)tp,
              (uint32_t)tp->refs - 1, (uint32_t)tp->prio, states[tp->state],
@@ -2038,6 +2063,9 @@ static const VNAShellCommand commands[] =
     {"transform"   , cmd_transform   , 0},
     {"threshold"   , cmd_threshold   , 0},
     {"help"        , cmd_help        , 0},
+#ifdef ENABLE_INFO_COMMAND
+    {"info"        , cmd_info        , 0},
+#endif
 #ifdef ENABLE_THREADS_COMMAND
     {"threads"     , cmd_threads     , 0},
 #endif

--- a/mcuconf.h
+++ b/mcuconf.h
@@ -58,7 +58,8 @@
 #define STM32_ADCSW                         STM32_ADCSW_HSI14
 #define STM32_USBSW                         STM32_USBSW_HSI48
 #define STM32_CECSW                         STM32_CECSW_HSI
-#define STM32_I2C1SW                        STM32_I2C1SW_HSI
+//#define STM32_I2C1SW                        STM32_I2C1SW_HSI
+#define STM32_I2C1SW                        STM32_I2C1SW_SYSCLK
 #define STM32_USART1SW                      STM32_USART1SW_PCLK
 #define STM32_RTCSEL                        STM32_RTCSEL_LSI
 

--- a/nanovna.h
+++ b/nanovna.h
@@ -86,7 +86,9 @@ double my_atof(const char *p);
 void toggle_sweep(void);
 void loadDefaultProps(void);
 
-extern int8_t sweep_enabled;
+#define SWEEP_MODE_ENABLED			0x01
+#define SWEEP_MODE_RUN_ONCE			0x02
+extern volatile int8_t sweep_mode;
 
 /*
  * dsp.c
@@ -279,12 +281,12 @@ int marker_search(void);
 int marker_search_left(int from);
 int marker_search_right(int from);
 
-extern uint16_t redraw_request;
-
+// _request flag for update screen
 #define REDRAW_CELLS      (1<<0)
 #define REDRAW_FREQUENCY  (1<<1)
 #define REDRAW_CAL_STATUS (1<<2)
 #define REDRAW_MARKER     (1<<3)
+extern volatile uint8_t redraw_request;
 
 extern int16_t vbat;
 

--- a/nanovna.h
+++ b/nanovna.h
@@ -86,9 +86,7 @@ double my_atof(const char *p);
 void toggle_sweep(void);
 void loadDefaultProps(void);
 
-#define SWEEP_MODE_ENABLED			0x01
-#define SWEEP_MODE_RUN_ONCE			0x02
-extern volatile int8_t sweep_mode;
+extern int8_t sweep_enabled;
 
 /*
  * dsp.c
@@ -224,10 +222,6 @@ typedef struct config {
 } config_t;
 
 extern config_t config;
-
-#define DRIVE_STRENGTH_AUTO (-1)
-#define FREQ_HARMONICS (config.harmonic_freq_threshold)
-#define IS_HARMONIC_MODE(f) ((f) > FREQ_HARMONICS)
 
 //extern trace_t trace[TRACES_MAX];
 

--- a/nanovna.h
+++ b/nanovna.h
@@ -89,6 +89,7 @@ void loadDefaultProps(void);
 #define SWEEP_ENABLE  0x01
 #define SWEEP_ONCE    0x02
 extern int8_t sweep_mode;
+extern const char *info_about[];
 
 /*
  * dsp.c

--- a/nanovna.h
+++ b/nanovna.h
@@ -218,8 +218,8 @@ typedef struct config {
   int16_t  touch_cal[4];
   int8_t   reserved_1;
   uint32_t harmonic_freq_threshold;
-
-  uint8_t _reserved[24];
+  uint16_t vbat_offset;
+  uint8_t _reserved[22];
   uint32_t checksum;
 } config_t;
 
@@ -234,7 +234,6 @@ void set_trace_refpos(int t, float refpos);
 float get_trace_scale(int t);
 float get_trace_refpos(int t);
 const char *get_trace_typename(int t);
-void draw_battery_status(void);
 
 void set_electrical_delay(float picoseconds);
 float get_electrical_delay(void);
@@ -282,9 +281,8 @@ int marker_search_right(int from);
 #define REDRAW_FREQUENCY  (1<<1)
 #define REDRAW_CAL_STATUS (1<<2)
 #define REDRAW_MARKER     (1<<3)
+#define REDRAW_BATTERY    (1<<4)
 extern volatile uint8_t redraw_request;
-
-extern int16_t vbat;
 
 /*
  * ili9341.c
@@ -468,11 +466,11 @@ void enter_dfu(void);
  */
 
 void adc_init(void);
-uint16_t adc_single_read(ADC_TypeDef *adc, uint32_t chsel);
-void adc_start_analog_watchdogd(ADC_TypeDef *adc, uint32_t chsel);
-void adc_stop(ADC_TypeDef *adc);
-void adc_interrupt(ADC_TypeDef *adc);
-int16_t adc_vbat_read(ADC_TypeDef *adc);
+uint16_t adc_single_read(uint32_t chsel);
+void adc_start_analog_watchdogd(uint32_t chsel);
+void adc_stop(void);
+void adc_interrupt(void);
+int16_t adc_vbat_read(void);
 
 /*
  * misclinous

--- a/nanovna.h
+++ b/nanovna.h
@@ -86,7 +86,9 @@ double my_atof(const char *p);
 void toggle_sweep(void);
 void loadDefaultProps(void);
 
-extern int8_t sweep_enabled;
+#define SWEEP_ENABLE  0x01
+#define SWEEP_ONCE    0x02
+extern int8_t sweep_mode;
 
 /*
  * dsp.c

--- a/nanovna.h
+++ b/nanovna.h
@@ -89,30 +89,6 @@ void loadDefaultProps(void);
 extern int8_t sweep_enabled;
 
 /*
- *  flash.c
- */
-#define SAVEAREA_MAX 5
-// Begin addr                   0x08018000
-#define SAVE_CONFIG_AREA_SIZE   0x00008000
-// config save area
-#define SAVE_CONFIG_ADDR        0x08018000
-// properties_t save area
-#define SAVE_PROP_CONFIG_0_ADDR 0x08018800
-#define SAVE_PROP_CONFIG_1_ADDR 0x0801a000
-#define SAVE_PROP_CONFIG_2_ADDR 0x0801b800
-#define SAVE_PROP_CONFIG_3_ADDR 0x0801d000
-#define SAVE_PROP_CONFIG_4_ADDR 0x0801e800
-
-/*
- * ui.c
- */
-extern void ui_init(void);
-extern void ui_process(void);
-
-enum opreq { OP_NONE = 0, OP_LEVER, OP_TOUCH, OP_FREQCHANGE };
-extern uint8_t operation_requested;
-
-/*
  * dsp.c
  */
 // 5ms @ 48kHz
@@ -133,9 +109,6 @@ void reset_dsp_accumerator(void);
 void calculate_gamma(float *gamma);
 void fetch_amplitude(float *gamma);
 void fetch_amplitude_ref(float *gamma);
-
-int si5351_set_frequency_with_offset(uint32_t freq, int offset, uint8_t drive_strength);
-
 
 /*
  * tlv320aic3204.c
@@ -249,6 +222,10 @@ typedef struct config {
 } config_t;
 
 extern config_t config;
+
+#define DRIVE_STRENGTH_AUTO (-1)
+#define FREQ_HARMONICS (config.harmonic_freq_threshold)
+#define IS_HARMONIC_MODE(f) ((f) > FREQ_HARMONICS)
 
 //extern trace_t trace[TRACES_MAX];
 
@@ -366,6 +343,16 @@ void show_logo(void);
  * flash.c
  */
 #define SAVEAREA_MAX 5
+// Begin addr                   0x08018000
+#define SAVE_CONFIG_AREA_SIZE   0x00008000
+// config save area
+#define SAVE_CONFIG_ADDR        0x08018000
+// properties_t save area
+#define SAVE_PROP_CONFIG_0_ADDR 0x08018800
+#define SAVE_PROP_CONFIG_1_ADDR 0x0801a000
+#define SAVE_PROP_CONFIG_2_ADDR 0x0801b800
+#define SAVE_PROP_CONFIG_3_ADDR 0x0801d000
+#define SAVE_PROP_CONFIG_4_ADDR 0x0801e800
 
 typedef struct properties {
   uint32_t magic;
@@ -432,6 +419,15 @@ void clear_all_config_prop_data(void);
 /*
  * ui.c
  */
+extern void ui_init(void);
+extern void ui_process(void);
+
+// Irq operation process set
+#define OP_NONE       0x00
+#define OP_LEVER      0x01
+#define OP_TOUCH      0x02
+//#define OP_FREQCHANGE 0x04
+extern volatile uint8_t operation_requested;
 
 // lever_mode
 enum lever_mode {
@@ -448,13 +444,13 @@ typedef struct uistat {
   int8_t digit_mode;
   int8_t current_trace; /* 0..3 */
   uint32_t value; // for editing at numeric input area
-  uint32_t previous_value;
+//  uint32_t previous_value;
   uint8_t lever_mode;
-  bool marker_delta;
+  uint8_t marker_delta;
+  uint8_t marker_tracking;
 } uistat_t;
 
 extern uistat_t uistat;
-  
 void ui_init(void);
 void ui_show(void);
 void ui_hide(void);

--- a/plot.c
+++ b/plot.c
@@ -6,6 +6,7 @@
 #include "nanovna.h"
 
 static void cell_draw_marker_info(int x0, int y0);
+static void draw_battery_status(void);
 
 int16_t grid_offset;
 int16_t grid_width;
@@ -1388,6 +1389,8 @@ draw_all(bool flush)
     draw_frequencies();
   if (redraw_request & REDRAW_CAL_STATUS)
     draw_cal_status();
+  if (redraw_request & REDRAW_BATTERY)
+    draw_battery_status();
   redraw_request = 0;
 }
 
@@ -1661,10 +1664,10 @@ draw_cal_status(void)
 #define BATTERY_BOTTOM_LEVEL    3100
 #define BATTERY_WARNING_LEVEL   3300
 
-void
-draw_battery_status(void)
+static void draw_battery_status(void)
 {
-  if (vbat<=0)
+  int16_t vbat = adc_vbat_read();
+  if (vbat <= 0)
     return;
   uint8_t string_buf[16];
   // Set battery color

--- a/plot.c
+++ b/plot.c
@@ -1056,7 +1056,6 @@ static int greater(int x, int y) { return x > y; }
 static int lesser(int x, int y) { return x < y; }
 
 static int (*compare)(int x, int y) = lesser;
-int8_t marker_tracking = false;
 
 int
 marker_search(void)

--- a/si5351.c
+++ b/si5351.c
@@ -321,11 +321,12 @@ si5351_set_frequency(int channel, uint32_t freq, uint8_t drive_strength){
  *  +-----------------------------------------------------------------------------------------------------------------------+
  *  |     Band 1      |   Band 2     |    Band 3    |   Band 2     |                       Band 3                           |
  *  +-----------------------------------------------------------------------------------------------------------------------+
- *  |    x1 :  x1     |    x1 : x1   |    x1 : x1   |    x3 : x5   |   x3 : x5  |    x5-x7    |    x7-x9     |    x9-x11    |
+ *  |            Direct mode  x1 :  x1              |           x3 : x5         |    x5-x7    |    x7-x9     |    x9-x11    |
+ *  +-----------------------------------------------------------------------------------------------------------------------+
  *  | 50kHz - 100MHz  | 100 - 150MHz | 150 - 300MHz |  300-450MHz  | 450-900MHz | 900-1500MHz | 1500-2100MHz | 2100-2700MHz |
  *  +-----------------------------------------------------------------------------------------------------------------------+
- *  |              f = 50kHz-100MHz                 | f=100-150    | f=150-300  | f=150-300   | f=214-300    | f=233-300    |
- *  |             of = 50kHz-100MHz                 |of= 60- 90    |of= 90-180  |of=128-215   |of=166-234    |of=190-246    |
+ *  |              f = 50kHz-300MHz                 | f=100-150    | f=150-300  | f=150-300   | f=214-300    | f=233-300    |
+ *  |             of = 50kHz-300MHz                 |of= 60- 90    |of= 90-180  |of=128-215   |of=166-234    |of=190-246    |
  *  +-----------------------------------------------------------------------------------------------------------------------+
  */
 static inline uint8_t si5351_getBand(uint32_t freq){
@@ -339,8 +340,8 @@ static inline uint8_t si5351_getBand(uint32_t freq){
 // Additional delay for band 1 (remove unstable generation at begin)
 #define DELAY_BAND_1	 1
 // Band changes need additional delay after reset PLL
-#define DELAY_BANDCHANGE_1 3
-#define DELAY_BANDCHANGE_2 3
+#define DELAY_BANDCHANGE_1 2
+#define DELAY_BANDCHANGE_2 2
 
 /*
  * Maximum supported frequency = FREQ_HARMONICS * 9U

--- a/si5351.c
+++ b/si5351.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014-2015, TAKAHASHI Tomohiro (TTRFTECH) edy555@gmail.com
+ * Modified by DiSlord dislordlive@gmail.com
  * All rights reserved.
  *
  * This is free software; you can redistribute it and/or modify
@@ -21,15 +22,19 @@
 #include "nanovna.h"
 #include "si5351.h"
 
-#define XTALFREQ 26000000L
-// MCLK (processor clock, audio codec) frequency clock
-#define CLK2_FREQUENCY 8000000L
+// Enable cache for SI5351 CLKX_CONTROL register, little speedup exchange
+#define USE_CLK_CONTROL_CACHE        TRUE
 
-// Fixed PLL mode multiplier
+// XTAL frequency on si5351
+#define XTALFREQ 26000000U
+// MCLK (processor clock if set, audio codec) frequency clock
+#define CLK2_FREQUENCY 8000000U
+
+// Fixed PLL mode multiplier (used in band 1)
 #define PLL_N 32
 
-//
-#define SI5351_I2C_ADDR   	(0x60<<1)
+// I2C address on bus (only 0x60 for Si5351A in 10-Pin MSOP)
+#define SI5351_I2C_ADDR   	0x60
 
 static uint8_t  current_band = 0;
 static uint32_t current_freq = 0;
@@ -37,18 +42,17 @@ static uint32_t current_freq = 0;
 static void
 si5351_bulk_write(const uint8_t *buf, int len)
 {
-  int addr = SI5351_I2C_ADDR>>1;
   i2cAcquireBus(&I2CD1);
-  (void)i2cMasterTransmitTimeout(&I2CD1, addr, buf, len, NULL, 0, 1000);
+  (void)i2cMasterTransmitTimeout(&I2CD1, SI5351_I2C_ADDR, buf, len, NULL, 0, 1000);
   i2cReleaseBus(&I2CD1);
 }
 #if 0
 static void si5351_bulk_read(uint8_t reg, uint8_t* buf, int len)
 {
-    int addr = SI5351_I2C_ADDR>>1;
-    i2cAcquireBus(&I2CD1);
-    msg_t mr = i2cMasterTransmitTimeout(&I2CD1, addr, &reg, 1, buf, len, 1000);
-    i2cReleaseBus(&I2CD1);
+  int addr = SI5351_I2C_ADDR>>1;
+  i2cAcquireBus(&I2CD1);
+  msg_t mr = i2cMasterTransmitTimeout(&I2CD1, addr, &reg, 1, buf, len, 1000);
+  i2cReleaseBus(&I2CD1);
 }
 #endif
 
@@ -64,15 +68,18 @@ const uint8_t si5351_configs[] = {
   2, SI5351_REG_3_OUTPUT_ENABLE_CONTROL, 0xff,
   4, SI5351_REG_16_CLK0_CONTROL, SI5351_CLK_POWERDOWN, SI5351_CLK_POWERDOWN, SI5351_CLK_POWERDOWN,
   2, SI5351_REG_183_CRYSTAL_LOAD, SI5351_CRYSTAL_LOAD_8PF,
+// All of this init code run late on sweep
+#if 0
   // setup PLL (26MHz * 32 = 832MHz, 32/2-2=14)
-//  9, SI5351_REG_PLL_A, /*P3*/0, 1, /*P1*/0, 14, 0, /*P3/P2*/0, 0, 0,
-//  9, SI5351_REG_PLL_B, /*P3*/0, 1, /*P1*/0, 14, 0, /*P3/P2*/0, 0, 0,
+  9, SI5351_REG_PLL_A, /*P3*/0, 1, /*P1*/0, 14, 0, /*P3/P2*/0, 0, 0,
+  9, SI5351_REG_PLL_B, /*P3*/0, 1, /*P1*/0, 14, 0, /*P3/P2*/0, 0, 0,
   // RESET PLL
   2, SI5351_REG_177_PLL_RESET, SI5351_PLL_RESET_A | SI5351_PLL_RESET_B | 0x0C, //
   // setup multisynth (832MHz / 104 = 8MHz, 104/2-2=50)
-//  9, SI5351_REG_58_MULTISYNTH2, /*P3*/0, 1, /*P1*/0, 50, 0, /*P2|P3*/0, 0, 0,
-//  2, SI5351_REG_18_CLK2_CONTROL, SI5351_CLK_DRIVE_STRENGTH_2MA | SI5351_CLK_INPUT_MULTISYNTH_N | SI5351_CLK_INTEGER_MODE,
-//  2, SI5351_REG_3_OUTPUT_ENABLE_CONTROL, 0,
+  9, SI5351_REG_58_MULTISYNTH2, /*P3*/0, 1, /*P1*/0, 50, 0, /*P2|P3*/0, 0, 0,
+  2, SI5351_REG_18_CLK2_CONTROL, SI5351_CLK_DRIVE_STRENGTH_2MA | SI5351_CLK_INPUT_MULTISYNTH_N | SI5351_CLK_INTEGER_MODE,
+  2, SI5351_REG_3_OUTPUT_ENABLE_CONTROL, 0,
+#endif
   0 // sentinel
 };
 
@@ -106,217 +113,185 @@ static const uint8_t clkctrl[] = {
   SI5351_REG_18_CLK2_CONTROL
 };
 
+// Reset PLL need then band changes
 static void si5351_reset_pll(uint8_t mask)
 {
   // Writing a 1<<5 will reset PLLA, 1<<7 reset PLLB, this is a self clearing bits.
   // !!! Need delay before reset PLL for apply PLL freq changes before
   chThdSleepMicroseconds(200);
   si5351_write(SI5351_REG_177_PLL_RESET, mask | 0x0C);
-//  chThdSleepMicroseconds(250);
 }
 
 void si5351_disable_output(void)
 {
-//  si5351_write(SI5351_REG_3_OUTPUT_ENABLE_CONTROL, (SI5351_CLK0_EN|SI5351_CLK1_EN|SI5351_CLK2_EN));
-  si5351_write(SI5351_REG_3_OUTPUT_ENABLE_CONTROL, 0xff);
+  si5351_write(SI5351_REG_3_OUTPUT_ENABLE_CONTROL, 0xFF);
   si5351_bulk_write(disable_output, sizeof(disable_output));
 }
 
 void si5351_enable_output(void)
 {
-  si5351_reset_pll( SI5351_PLL_RESET_A | SI5351_PLL_RESET_B );
-//  si5351_write(SI5351_REG_3_OUTPUT_ENABLE_CONTROL, ~(SI5351_CLK0_EN|SI5351_CLK1_EN|SI5351_CLK2_EN));
-  si5351_write(SI5351_REG_3_OUTPUT_ENABLE_CONTROL, 0x00);
+  si5351_write(SI5351_REG_3_OUTPUT_ENABLE_CONTROL, ~(SI5351_CLK0_EN|SI5351_CLK1_EN|SI5351_CLK2_EN));
+//si5351_reset_pll(SI5351_PLL_RESET_A | SI5351_PLL_RESET_B);
   current_freq = 0;
   current_band = 0;
 }
 
-static void si5351_setupPLL(uint8_t pll, /* SI5351_PLL_A or SI5351_PLL_B */
-                     uint8_t     mult,
-                     uint32_t    num,
-                     uint32_t    denom)
+// Set PLL freq = XTALFREQ * (mult + num/denom)
+static void si5351_setupPLL(uint8_t   pllSource,  /* SI5351_REG_PLL_A or SI5351_REG_PLL_B */
+                            uint32_t  mult,
+                            uint32_t  num,
+                            uint32_t  denom)
 {
-  uint32_t P1;
-  uint32_t P2;
-  uint32_t P3;
-
   /* Feedback Multisynth Divider Equation
    * where: a = mult, b = num and c = denom
    * P1 register is an 18-bit value using following formula:
-   * 	P1[17:0] = 128 * mult + floor(128*(num/denom)) - 512
+   * 	P1[17:0] = 128 * mult + int((128*num)/denom) - 512
    * P2 register is a 20-bit value using the following formula:
-   * 	P2[19:0] = 128 * num - denom * floor(128*(num/denom))
+   * 	P2[19:0] = (128 * num) % denom
    * P3 register is a 20-bit value using the following formula:
    * 	P3[19:0] = denom
    */
-
   /* Set the main PLL config registers */
-  if (num == 0)
-  {
-    /* Integer mode */
-    P1 = 128 * mult - 512;
-    P2 = 0;
-    P3 = 1;
-  }
-  else
-  {
-    /* Fractional mode */
-    //P1 = (uint32_t)(128 * mult + floor(128 * ((float)num/(float)denom)) - 512);
-    P1 = 128 * mult + ((128 * num) / denom) - 512;
-    //P2 = (uint32_t)(128 * num - denom * floor(128 * ((float)num/(float)denom)));
-    P2 = 128 * num - denom * ((128 * num) / denom);
+  mult<<=7;
+  num<<=7;
+  uint32_t P1 = mult - 512; // Integer mode
+  uint32_t P2 = 0;
+  uint32_t P3 = 1;
+  if (num){                 // Fractional mode
+    P1+= num / denom;
+    P2 = num % denom;
     P3 = denom;
   }
-// Pll MSN(A|B) registers Datasheet
-//      MSN_P3[15:8]
-//      MSN_P3[ 7:0]
-// Reserved      | MSN_P1[17:16]
-//       MSN_P1[15:8]
-//       MSN_P1[ 7:0]
-// MSN_P3[19:16] | MSN_P2[19:16]
-//       MSN_P2[15:8]
-//       MSN_P2[ 7:0]
+  // Pll MSN(A|B) registers Datasheet
   uint8_t reg[9];
-  reg[0] = pll;//reg_base[pll];
-  reg[1] = (P3 & 0x0000FF00) >> 8;
-  reg[2] = (P3 & 0x000000FF);
-  reg[3] = (P1 & 0x00030000) >> 16;
-  reg[4] = (P1 & 0x0000FF00) >> 8;
-  reg[5] = (P1 & 0x000000FF);
-  reg[6] = ((P3 & 0x000F0000) >> 12) | ((P2 & 0x000F0000) >> 16);
-  reg[7] = (P2 & 0x0000FF00) >> 8;
-  reg[8] = (P2 & 0x000000FF);
+  reg[0]= pllSource;                                // SI5351_REG_PLL_A or SI5351_REG_PLL_B
+  reg[1]=( P3 & 0x0FF00)>> 8;                       // MSN_P3[15: 8]
+  reg[2]=( P3 & 0x000FF);                           // MSN_P3[ 7: 0]
+  reg[3]=( P1 & 0x30000)>>16;                       // MSN_P1[17:16]
+  reg[4]=( P1 & 0x0FF00)>> 8;                       // MSN_P1[15: 8]
+  reg[5]=( P1 & 0x000FF);                           // MSN_P1[ 7: 0]
+  reg[6]=((P3 & 0xF0000)>>12)|((P2 & 0xF0000)>>16); // MSN_P3[19:16] | MSN_P2[19:16]
+  reg[7]=( P2 & 0x0FF00)>> 8;                       // MSN_P2[15: 8]
+  reg[8]=( P2 & 0x000FF);                           // MSN_P2[ 7: 0]
   si5351_bulk_write(reg, 9);
 }
 
-
+// Set Multisynth divider = (div + num/denom) * rdiv
 static void
-si5351_setupMultisynth(uint8_t     channel,
-                       uint8_t     pllSource,
-                       uint32_t    div, // 4,6,8, 8+ ~ 900
-                       uint32_t    num,
-                       uint32_t    denom,
-                       uint32_t    rdiv, // SI5351_R_DIV_1~128
-                       uint8_t     drive_strength)
+si5351_setupMultisynth(uint8_t   channel,
+                       uint32_t  div,    // 4,6,8, 8+ ~ 900
+                       uint32_t  num,
+                       uint32_t  denom,
+                       uint32_t  rdiv,   // SI5351_R_DIV_1~128
+                       uint8_t   chctrl) // SI5351_REG_16_CLKX_CONTROL settings
 {
-  uint8_t dat;
-
-  uint32_t P1;
-  uint32_t P2;
-  uint32_t P3;
-  uint32_t div4 = 0;
-
   /* Output Multisynth Divider Equations
    * where: a = div, b = num and c = denom
    * P1 register is an 18-bit value using following formula:
-   * 	P1[17:0] = 128 * a + floor(128*(b/c)) - 512
+   *   P1[17:0] = 128 * a + int((128*b)/c) - 512
    * P2 register is a 20-bit value using the following formula:
-   * 	P2[19:0] = 128 * b - c * floor(128*(b/c))
+   *   P2[19:0] = (128 * b) % c
    * P3 register is a 20-bit value using the following formula:
-   * 	P3[19:0] = c
+   *   P3[19:0] = c
    */
   /* Set the main PLL config registers */
-  if (div == 4) {
-    div4 = SI5351_DIVBY4;
-    P1 = P2 = 0;
-    P3 = 1;
-  } else if (num == 0) {
-    /* Integer mode */
-    P1 = 128 * div - 512;
-    P2 = 0;
-    P3 = 1;
-  } else {
-    /* Fractional mode */
-    P1 = 128 * div + ((128 * num) / denom) - 512;
-    P2 = 128 * num - denom * ((128 * num) / denom);
-    P3 = denom;
+  uint32_t P1 = 0;
+  uint32_t P2 = 0;
+  uint32_t P3 = 1;
+  if (div == 4)
+    rdiv|= SI5351_DIVBY4;
+  else {
+    num<<=7;
+    div<<=7;
+    P1 = div - 512; // Integer mode
+    if (num){       // Fractional mode
+      P1+= num / denom;
+      P2 = num % denom;
+      P3 = denom;
+    }
   }
-
   /* Set the MSx config registers */
   uint8_t reg[9];
-  reg[0] = msreg_base[channel];
-  reg[1] = (P3 & 0x0000FF00) >> 8;
-  reg[2] = (P3 & 0x000000FF);
-  reg[3] = ((P1 & 0x00030000) >> 16) | div4 | rdiv;
-  reg[4] = (P1 & 0x0000FF00) >> 8;
-  reg[5] = (P1 & 0x000000FF);
-  reg[6] = ((P3 & 0x000F0000) >> 12) | ((P2 & 0x000F0000) >> 16);
-  reg[7] = (P2 & 0x0000FF00) >> 8;
-  reg[8] = (P2 & 0x000000FF);
+  reg[0]= msreg_base[channel];                      // SI5351_REG_42_MULTISYNTH0, SI5351_REG_50_MULTISYNTH1, SI5351_REG_58_MULTISYNTH2
+  reg[1]=( P3 & 0x0FF00)>>8;                        // MSx_P3[15: 8]
+  reg[2]=( P3 & 0x000FF);                           // MSx_P3[ 7: 0]
+  reg[3]=((P1 & 0x30000)>>16)| rdiv;                // Rx_DIV[2:0] | MSx_DIVBY4[1:0] | MSx_P1[17:16]
+  reg[4]=( P1 & 0x0FF00)>> 8;                       // MSx_P1[15: 8]
+  reg[5]=( P1 & 0x000FF);                           // MSx_P1[ 7: 0]
+  reg[6]=((P3 & 0xF0000)>>12)|((P2 & 0xF0000)>>16); // MSx_P3[19:16] | MSx_P2[19:16]
+  reg[7]=( P2 & 0x0FF00)>>8;                        // MSx_P2[15: 8]
+  reg[8]=( P2 & 0x000FF);                           // MSx_P2[ 7: 0]
   si5351_bulk_write(reg, 9);
 
   /* Configure the clk control and enable the output */
-  dat = drive_strength | SI5351_CLK_INPUT_MULTISYNTH_N;
-  if (pllSource == SI5351_REG_PLL_B)
-    dat |= SI5351_CLK_PLL_SELECT_B;
+  uint8_t dat = chctrl | SI5351_CLK_INPUT_MULTISYNTH_N;
   if (num == 0)
     dat |= SI5351_CLK_INTEGER_MODE;
+
+#if USE_CLK_CONTROL_CACHE == TRUE
+  // Use cache for this reg, not update if not change
+  static uint8_t clk_cache[3];
+  if (clk_cache[channel]!=dat){
+    si5351_write(clkctrl[channel], dat);
+    clk_cache[channel]=dat;
+  }
+#else
   si5351_write(clkctrl[channel], dat);
+#endif
 }
 
-static void
-si5351_set_frequency_fixedpll(uint8_t channel, uint32_t pllSource, uint64_t pllfreq, uint32_t freq, uint32_t rdiv, uint8_t drive_strength)
-{
-	uint32_t denom = freq;
-	uint32_t div = pllfreq / denom; // range: 8 ~ 1800
-	uint32_t num = pllfreq % denom;
-
-    // cf. https://github.com/python/cpython/blob/master/Lib/fractions.py#L227
-	uint32_t max_denominator = (1 << 20) - 1;
-    if (denom > max_denominator) {
-    	uint32_t p0 = 0, q0 = 1, p1 = 1, q1 = 0;
-      while (denom != 0) {
-    	  uint32_t a = num / denom;
-    	  uint32_t b = num % denom;
-    	  uint32_t q2 = q0 + a*q1;
-        if (q2 > max_denominator)
-          break;
-        uint32_t p2 = p0 + a*p1;
-        p0 = p1;
-        q0 = q1;
-        p1 = p2;
-        q1 = q2;
-        num = denom; denom = b;
-      }
-      num = p1;
-      denom = q1;
-    }
-    si5351_setupMultisynth(channel, pllSource, div, num, denom, rdiv, drive_strength);
-}
-
-void si5351_setupPLL_freq(uint32_t pll, uint32_t freq, uint32_t div, uint32_t mul){
-  uint32_t denom = XTALFREQ * mul;
-  uint64_t pllfreq = (uint64_t)freq * div;
-  uint32_t multi = pllfreq / denom;
-  uint32_t num   = pllfreq % denom;
-
+// Find better approximate values for n/d
+#define MAX_DENOMINATOR ((1 << 20) - 1)
+static inline void fractionalSolve(uint32_t *n, uint32_t *d){
   // cf. https://github.com/python/cpython/blob/master/Lib/fractions.py#L227
-  uint32_t max_denominator = (1 << 20) - 1;
-  if (denom > max_denominator) {
+  uint32_t denom = *d;
+  if (denom > MAX_DENOMINATOR) {
+    uint32_t num = *n;
     uint32_t p0 = 0, q0 = 1, p1 = 1, q1 = 0;
     while (denom != 0) {
-	  uint32_t a = num / denom;
-	  uint32_t b = num % denom;
-	  uint32_t q2 = q0 + a*q1;
-      if (q2 > max_denominator)
+      uint32_t a = num / denom;
+      uint32_t b = num % denom;
+      uint32_t q2 = q0 + a*q1;
+      if (q2 > MAX_DENOMINATOR)
         break;
       uint32_t p2 = p0 + a*p1;
       p0 = p1; q0 = q1; p1 = p2; q1 = q2;
       num = denom; denom = b;
     }
-    num = p1;
-    denom = q1;
+    *n = p1;
+    *d = q1;
   }
-  si5351_setupPLL(pll, multi, num, denom);
+}
+
+// Setup Multisynth divider for get correct output freq if fixed PLL = pllfreq
+static void
+si5351_set_frequency_fixedpll(uint8_t channel, uint64_t pllfreq, uint32_t freq, uint32_t rdiv, uint8_t chctrl)
+{
+  uint32_t denom = freq;
+  uint32_t div = pllfreq / denom; // range: 8 ~ 1800
+  uint32_t num = pllfreq % denom;
+  fractionalSolve(&num, &denom);
+  si5351_setupMultisynth(channel, div, num, denom, rdiv, chctrl);
+}
+
+// Setup PLL freq if Multisynth divider fixed = div (need get output =  freq/mul)
+static void
+si5351_setupPLL_freq(uint32_t pllSource, uint32_t freq, uint32_t div, uint32_t mul){
+  uint32_t denom = XTALFREQ * mul;
+  uint64_t pllfreq = (uint64_t)freq * div;
+  uint32_t multi = pllfreq / denom;
+  uint32_t num   = pllfreq % denom;
+  fractionalSolve(&num, &denom);
+  si5351_setupPLL(pllSource, multi, num, denom);
 }
 
 #if 0
 static void
 si5351_set_frequency_fixeddiv(uint8_t channel, uint32_t pll, uint32_t freq, uint32_t div,
-                              uint8_t drive_strength, uint32_t mul)
+                              uint8_t chctrl, uint32_t mul)
 {
   si5351_setupPLL_freq(pll, freq, div, mul);
-  si5351_setupMultisynth(channel, pll, div, 0, 1, SI5351_R_DIV_1, drive_strength);
+  si5351_setupMultisynth(channel, div, 0, 1, SI5351_R_DIV_1, chctrl);
 }
 
 void
@@ -332,91 +307,106 @@ si5351_set_frequency(int channel, uint32_t freq, uint8_t drive_strength){
 }
 #endif
 
+/*
+ * Frequency generation divide on 3 band
+ *  Band 1
+ *   1~100MHz      fixed PLL = XTALFREQ * PLL_N, fractional divider
+ *  Band 2
+ * 100~150MHz fractional PLL = 600- 900MHz, fixed divider 'fdiv = 6'
+ *  Band 3
+ * 150~300MHz fractional PLL = 600-1200MHz, fixed divider 'fdiv = 4'
+ *
+ * For FREQ_HARMONICS = 300MHz - band range is:
+ *  +-----------------------------------------------------------------------------------------------------------------------+
+ *  |     Band 1      |   Band 2     |    Band 3    |   Band 2     |                       Band 3                           |
+ *  +-----------------------------------------------------------------------------------------------------------------------+
+ *  |    x1 :  x1     |    x1 : x1   |    x1 : x1   |    x3 : x5   |   x3 : x5  |    x5-x7    |    x7-x9     |    x9-x11    |
+ *  | 50kHz - 100MHz  | 100 - 150MHz | 150 - 300MHz |  300-450MHz  | 450-900MHz | 900-1500MHz | 1500-2100MHz | 2100-2700MHz |
+ *  +-----------------------------------------------------------------------------------------------------------------------+
+ *  |              f = 50kHz-100MHz                 | f=100-150    | f=150-300  | f=150-300   | f=214-300    | f=233-300    |
+ *  |             of = 50kHz-100MHz                 |of= 60- 90    |of= 90-180  |of=128-215   |of=166-234    |of=190-246    |
+ *  +-----------------------------------------------------------------------------------------------------------------------+
+ */
+static inline uint8_t si5351_getBand(uint32_t freq){
+  if (freq < 100000000U) return 1;
+  if (freq < 150000000U) return 2;
+  return 3;
+}
+
+// Minimum value is 2, freq change apply at next dsp measure, and need skip it
 #define DELAY_NORMAL 2
+// Additional delay for band 1 (remove unstable generation at begin)
+#define DELAY_BAND_1	 1
+// Band changes need additional delay after reset PLL
 #define DELAY_BANDCHANGE 2
 
 /*
+ * Maximum supported frequency = FREQ_HARMONICS * 9U
  * configure output as follows:
  * CLK0: frequency + offset
  * CLK1: frequency
  * CLK2: fixed 8MHz
  */
-
 int
-si5351_set_frequency_with_offset(uint32_t freq, int offset, uint8_t drive_strength)
-{
+si5351_set_frequency_with_offset(uint32_t freq, int offset, uint8_t drive_strength){
   uint8_t band;
   int delay = DELAY_NORMAL;
   if (freq == current_freq)
-	  return delay;
+    return delay;
   uint32_t ofreq = freq + offset;
   uint32_t mul = 1, omul = 1;
   uint32_t rdiv = SI5351_R_DIV_1;
   uint32_t fdiv;
   current_freq = freq;
   if (freq >= FREQ_HARMONICS * 7U) {
-    mul = 9;
+     mul =  9;
     omul = 11;
   } else if (freq >= FREQ_HARMONICS * 5U) {
-    mul = 7;
+     mul = 7;
     omul = 9;
   } else if (freq >= FREQ_HARMONICS * 3U) {
-    mul = 5;
+     mul = 5;
     omul = 7;
   } else if (freq >= FREQ_HARMONICS) {
-    mul = 3;
+     mul = 3;
     omul = 5;
   }
   else if (freq <= 500000U) {
     rdiv = SI5351_R_DIV_64;
-    freq *= 64;
-    ofreq *= 64;
+     freq<<= 6;
+    ofreq<<= 6;
   } else if (freq <= 4000000U) {
     rdiv = SI5351_R_DIV_8;
-    freq *= 8;
-    ofreq *= 8;
+     freq<<= 3;
+    ofreq<<= 3;
   }
-  /*
-   *  Band 0
-   *   1~100MHz      fixed PLL = XTALFREQ * PLL_N, fractional divider
-   *  Band 1
-   * 100~150MHz fractional PLL = 600- 900MHz, fixed divider 6
-   *  Band 2
-   * 150~300MHz fractional PLL = 600-1200MHz, fixed divider 4
-   */
-  if ((freq / mul) < 100000000U) {
-    band = 1;
-  } else if ((freq / mul) < 150000000U) {
-    band = 2;
-    fdiv = 6;
-  } else {
-    band = 3;
-    fdiv = 4;
-  }
+
+  band = si5351_getBand(freq/mul);
   switch (band) {
   case 1:
-    // Setup CH0 and CH1 constant PLL freq at band change, and set CH2 freq = CLK2_FREQUENCY
+    // Setup CH0 and CH1 constant PLLA freq at band change, and set CH2 freq = CLK2_FREQUENCY
     if (current_band != 1){
       si5351_setupPLL(SI5351_REG_PLL_A, PLL_N, 0, 1);
-      si5351_setupPLL(SI5351_REG_PLL_B, PLL_N, 0, 1);
-      si5351_set_frequency_fixedpll(2, SI5351_REG_PLL_B, XTALFREQ * PLL_N, CLK2_FREQUENCY, SI5351_R_DIV_1, SI5351_CLK_DRIVE_STRENGTH_2MA);
+      si5351_set_frequency_fixedpll(2, XTALFREQ * PLL_N, CLK2_FREQUENCY, SI5351_R_DIV_1, SI5351_CLK_DRIVE_STRENGTH_2MA|SI5351_CLK_PLL_SELECT_A);
     }
     // Calculate and set CH0 and CH1 divider
-    si5351_set_frequency_fixedpll(0, SI5351_REG_PLL_A, XTALFREQ * PLL_N * omul, ofreq, rdiv, drive_strength);
-    si5351_set_frequency_fixedpll(1, SI5351_REG_PLL_A, XTALFREQ * PLL_N *  mul,  freq, rdiv, drive_strength);
+    si5351_set_frequency_fixedpll(0,  (uint64_t)omul * XTALFREQ * PLL_N, ofreq, rdiv, drive_strength|SI5351_CLK_PLL_SELECT_A);
+    si5351_set_frequency_fixedpll(1,  (uint64_t) mul * XTALFREQ * PLL_N,  freq, rdiv, drive_strength|SI5351_CLK_PLL_SELECT_A);
+    delay+=DELAY_BAND_1;
     break;
-  case 2:
-  case 3:
+  case 2:// fdiv = 6
+  case 3:// fdiv = 4;
+    fdiv = (band == 2) ? 6 : 4;
     // Setup CH0 and CH1 constant fdiv divider at change
     if (current_band != band){
-   	  si5351_setupMultisynth(0, SI5351_REG_PLL_A, fdiv, 0, 1, SI5351_R_DIV_1, drive_strength);
-      si5351_setupMultisynth(1, SI5351_REG_PLL_B, fdiv, 0, 1, SI5351_R_DIV_1, drive_strength);
+   	  si5351_setupMultisynth(0, fdiv, 0, 1, SI5351_R_DIV_1, drive_strength|SI5351_CLK_PLL_SELECT_A);
+      si5351_setupMultisynth(1, fdiv, 0, 1, SI5351_R_DIV_1, drive_strength|SI5351_CLK_PLL_SELECT_B);
     }
     // Calculate and set CH0 and CH1 PLL freq
     si5351_setupPLL_freq(SI5351_REG_PLL_A, ofreq, fdiv, omul);// set PLLA freq = (ofreq/omul)*fdiv
     si5351_setupPLL_freq(SI5351_REG_PLL_B,  freq, fdiv,  mul);// set PLLB freq = ( freq/ mul)*fdiv
     // Calculate CH2 freq = CLK2_FREQUENCY, depend from calculated before CH1 PLLB = (freq/mul)*fdiv
-    si5351_set_frequency_fixedpll(2, SI5351_REG_PLL_B, (freq/mul)*fdiv, CLK2_FREQUENCY, SI5351_R_DIV_1, SI5351_CLK_DRIVE_STRENGTH_2MA);
+    si5351_set_frequency_fixedpll(2, (uint64_t)freq*fdiv, CLK2_FREQUENCY*mul, SI5351_R_DIV_1, SI5351_CLK_DRIVE_STRENGTH_2MA|SI5351_CLK_PLL_SELECT_B);
     break;
   }
 

--- a/si5351.h
+++ b/si5351.h
@@ -17,8 +17,8 @@
  * the Free Software Foundation, Inc., 51 Franklin Street,
  * Boston, MA 02110-1301, USA.
  */
-#define SI5351_PLL_A	0
-#define SI5351_PLL_B	1
+//#define SI5351_PLL_A	0
+//#define SI5351_PLL_B	1
 
 #define SI5351_MULTISYNTH_DIV_4  4
 #define SI5351_MULTISYNTH_DIV_6  6
@@ -33,12 +33,16 @@
 #define SI5351_R_DIV_128	(7<<4)
 #define SI5351_DIVBY4 		(3<<2)
 
-#define SI5351_REG_3_OUTPUT_ENABLE_CONTROL 3
+#define SI5351_REG_3_OUTPUT_ENABLE_CONTROL  3
+#define SI5351_CLK0_EN     (1<<0)
+#define SI5351_CLK1_EN     (1<<2)
+#define SI5351_CLK2_EN     (1<<3)
+
 #define SI5351_REG_16_CLK0_CONTROL	16
 #define SI5351_REG_17_CLK1_CONTROL	17
 #define SI5351_REG_18_CLK2_CONTROL	18
-#define SI5351_REG_26_PLL_A 		26
-#define SI5351_REG_34_PLL_B 		34
+#define SI5351_REG_PLL_A 			26
+#define SI5351_REG_PLL_B 			34
 #define SI5351_REG_42_MULTISYNTH0	42
 #define SI5351_REG_50_MULTISYNTH1	50
 #define SI5351_REG_58_MULTISYNTH2	58
@@ -74,4 +78,7 @@
 
 void si5351_init(void);
 
-void si5351_set_frequency(int channel, int freq, uint8_t drive_strength);
+void si5351_disable_output(void);
+void si5351_enable_output(void);
+void si5351_set_frequency(int channel, uint32_t freq, uint8_t drive_strength);
+int  si5351_set_frequency_with_offset(uint32_t freq, int offset, uint8_t drive_strength);

--- a/si5351.h
+++ b/si5351.h
@@ -17,12 +17,39 @@
  * the Free Software Foundation, Inc., 51 Franklin Street,
  * Boston, MA 02110-1301, USA.
  */
-//#define SI5351_PLL_A	0
-//#define SI5351_PLL_B	1
 
-#define SI5351_MULTISYNTH_DIV_4  4
-#define SI5351_MULTISYNTH_DIV_6  6
-#define SI5351_MULTISYNTH_DIV_8  8
+#define SI5351_REG_3_OUTPUT_ENABLE_CONTROL  3
+#define SI5351_CLK0_EN     (1<<0)
+#define SI5351_CLK1_EN     (1<<1)
+#define SI5351_CLK2_EN     (1<<2)
+
+// Reg 16-18 CLKX_CONTROL
+#define SI5351_REG_16_CLK0_CONTROL	16
+#define SI5351_REG_17_CLK1_CONTROL	17
+#define SI5351_REG_18_CLK2_CONTROL	18
+#define SI5351_CLK_POWERDOWN			    (1<<7)
+#define SI5351_CLK_INTEGER_MODE		     	(1<<6)
+#define SI5351_CLK_PLL_SELECT_A		     	(0<<5)
+#define SI5351_CLK_PLL_SELECT_B		     	(1<<5)
+#define SI5351_CLK_INVERT				    (1<<4)
+#define SI5351_CLK_INPUT_MASK			    (3<<2)
+#define SI5351_CLK_INPUT_XTAL			    (0<<2)
+#define SI5351_CLK_INPUT_CLKIN			    (1<<2)
+#define SI5351_CLK_INPUT_MULTISYNTH_0_4 	(2<<2)
+#define SI5351_CLK_INPUT_MULTISYNTH_N	 	(3<<2)
+#define SI5351_CLK_DRIVE_STRENGTH_MASK		(3<<0)
+#define SI5351_CLK_DRIVE_STRENGTH_2MA		(0<<0)
+#define SI5351_CLK_DRIVE_STRENGTH_4MA		(1<<0)
+#define SI5351_CLK_DRIVE_STRENGTH_6MA	 	(2<<0)
+#define SI5351_CLK_DRIVE_STRENGTH_8MA		(3<<0)
+
+#define SI5351_REG_PLL_A 			26
+#define SI5351_REG_PLL_B 			34
+
+#define SI5351_REG_42_MULTISYNTH0	42
+#define SI5351_REG_50_MULTISYNTH1	50
+#define SI5351_REG_58_MULTISYNTH2	58
+#define SI5351_DIVBY4 		(3<<2)
 #define SI5351_R_DIV_1		(0<<4)
 #define SI5351_R_DIV_2		(1<<4)
 #define SI5351_R_DIV_4		(2<<4)
@@ -31,39 +58,6 @@
 #define SI5351_R_DIV_32		(5<<4)
 #define SI5351_R_DIV_64		(6<<4)
 #define SI5351_R_DIV_128	(7<<4)
-#define SI5351_DIVBY4 		(3<<2)
-
-#define SI5351_REG_3_OUTPUT_ENABLE_CONTROL  3
-#define SI5351_CLK0_EN     (1<<0)
-#define SI5351_CLK1_EN     (1<<2)
-#define SI5351_CLK2_EN     (1<<3)
-
-#define SI5351_REG_16_CLK0_CONTROL	16
-#define SI5351_REG_17_CLK1_CONTROL	17
-#define SI5351_REG_18_CLK2_CONTROL	18
-#define SI5351_REG_PLL_A 			26
-#define SI5351_REG_PLL_B 			34
-#define SI5351_REG_42_MULTISYNTH0	42
-#define SI5351_REG_50_MULTISYNTH1	50
-#define SI5351_REG_58_MULTISYNTH2	58
-
-#define SI5351_CLK_POWERDOWN			    (1<<7)
-#define SI5351_CLK_INTEGER_MODE		     	(1<<6)
-#define SI5351_CLK_PLL_SELECT_B		     	(1<<5)
-#define SI5351_CLK_INVERT				    (1<<4)
-
-#define SI5351_CLK_INPUT_MASK			    (3<<2)
-#define SI5351_CLK_INPUT_XTAL			    (0<<2)
-#define SI5351_CLK_INPUT_CLKIN			    (1<<2)
-#define SI5351_CLK_INPUT_MULTISYNTH_0_4 	(2<<2)
-#define SI5351_CLK_INPUT_MULTISYNTH_N	 	(3<<2)
-
-#define SI5351_CLK_DRIVE_STRENGTH_MASK		(3<<0)
-#define SI5351_CLK_DRIVE_STRENGTH_2MA		(0<<0)
-#define SI5351_CLK_DRIVE_STRENGTH_4MA		(1<<0)
-#define SI5351_CLK_DRIVE_STRENGTH_6MA	 	(2<<0)
-#define SI5351_CLK_DRIVE_STRENGTH_8MA		(3<<0)
-
 
 #define SI5351_REG_177_PLL_RESET 	177
 #define SI5351_PLL_RESET_B 			(1<<7)
@@ -74,11 +68,8 @@
 #define SI5351_CRYSTAL_LOAD_8PF  	(2<<6)
 #define SI5351_CRYSTAL_LOAD_10PF  	(3<<6)
 
-#define SI5351_CRYSTAL_FREQ_25MHZ 	25000000
-
 void si5351_init(void);
-
 void si5351_disable_output(void);
 void si5351_enable_output(void);
-void si5351_set_frequency(int channel, uint32_t freq, uint8_t drive_strength);
+//void si5351_set_frequency(int channel, uint32_t freq, uint8_t drive_strength);
 int  si5351_set_frequency_with_offset(uint32_t freq, int offset, uint8_t drive_strength);

--- a/tlv320aic3204.c
+++ b/tlv320aic3204.c
@@ -25,74 +25,78 @@
 
 #define wait_ms(ms)     chThdSleepMilliseconds(ms)
 
-static const uint8_t conf_data_pll[] = {
-  // len, ( reg, data ), 
-  2, 0x00, 0x00, /* Initialize to Page 0 */
-  2, 0x01, 0x01, /* Initialize the device through software reset */
-  2, 0x04, 0x43, /* PLL Clock High, MCLK, PLL */
+static const uint8_t conf_data[] = {
+// reg, data,
+// PLL clock config
+  0x00, 0x00, /* Initialize to Page 0 */
+  0x01, 0x01, /* Initialize the device through software reset */
+  0x04, 0x43, /* PLL Clock High, MCLK, PLL */
 #ifdef REFCLK_8000KHZ
   /* 8.000MHz*10.7520 = 86.016MHz, 86.016MHz/(2*7*128) = 48kHz */
-  2, 0x05, 0x91, /* Power up PLL, P=1,R=1 */
-  2, 0x06, 0x0a, /* J=10 */
-  2, 0x07, 29,    /* D=7520 = (29<<8) + 96 */
-  2, 0x08, 96,
+  0x05, 0x91, /* Power up PLL, P=1,R=1 */
+  0x06, 0x0a, /* J=10 */
+  0x07, 29,   /* D=7520 = (29<<8) + 96 */
+  0x08, 96,
 #endif
-  0 // sentinel
+// Clock config, default fs=48kHz
+  0x0b, 0x82, /* Power up the NDAC divider with value 2 */
+  0x0c, 0x87, /* Power up the MDAC divider with value 7 */
+  0x0d, 0x00, /* Program the OSR of DAC to 128 */
+  0x0e, 0x80,
+  0x3c, 0x08, /* Set the DAC Mode to PRB_P8 */
+  //0x3c, 25, /* Set the DAC Mode to PRB_P25 */
+  0x1b, 0x0c, /* Set the BCLK,WCLK as output */
+  0x1e, 0x80 + 28, /* Enable the BCLKN divider with value 28 */
+  0x25, 0xee, /* DAC power up */
+
+  0x12, 0x82, /* Power up the NADC divider with value 2 */
+  0x13, 0x87, /* Power up the MADC divider with value 7 */
+  0x14, 0x80, /* Program the OSR of ADC to 128 */
+  0x3d, 0x01, /* Select ADC PRB_R1 */
+// Data routing
+  0x00, 0x01, /* Select Page 1 */
+  0x01, 0x08, /* Disable Internal Crude AVdd in presence of external AVdd supply or before powering up internal AVdd LDO*/
+  0x02, 0x01, /* Enable Master Analog Power Control */
+  0x7b, 0x01, /* Set the REF charging time to 40ms */
+  0x14, 0x25, /* HP soft stepping settings for optimal pop performance at power up Rpop used is 6k with N = 6 and soft step = 20usec. This should work with 47uF coupling capacitor. Can try N=5,6 or 7 time constants as well. Trade-off delay vs “pop” sound. */
+  0x0a, 0x33, /* Set the Input Common Mode to 0.9V and Output Common Mode for Headphone to 1.65V */
+
+  0x3d, 0x00, /* Select ADC PTM_R4 */
+  0x47, 0x32, /* Set MicPGA startup delay to 3.1ms */
+  0x7b, 0x01, /* Set the REF charging time to 40ms */
+  0x34, 0x10, /* Route IN2L to LEFT_P with 10K */
+  0x36, 0x10, /* Route IN2R to LEFT_N with 10K */
+//0x37, 0x04, /* Route IN3R to RIGHT_P with 10K */
+//0x39, 0x04, /* Route IN3L to RIGHT_N with 10K */
+//0x3b, 0x00, /* Unmute Left MICPGA, Gain selection of 32dB to make channel gain 0dB */
+//0x3c, 0x00, /* Unmute Right MICPGA, Gain selection of 32dB to make channel gain 0dB */
 };
 
-// default fs=48kHz
-static const uint8_t conf_data_clk[] = {
-  2, 0x0b, 0x82, /* Power up the NDAC divider with value 2 */
-  2, 0x0c, 0x87, /* Power up the MDAC divider with value 7 */
-  2, 0x0d, 0x00, /* Program the OSR of DAC to 128 */
-  2, 0x0e, 0x80,
-  2, 0x3c, 0x08, /* Set the DAC Mode to PRB_P8 */
-  //2, 0x3c, 25, /* Set the DAC Mode to PRB_P25 */
-  2, 0x1b, 0x0c, /* Set the BCLK,WCLK as output */    
-  2, 0x1e, 0x80 + 28, /* Enable the BCLKN divider with value 28 */
-  2, 0x25, 0xee, /* DAC power up */
-
-  2, 0x12, 0x82, /* Power up the NADC divider with value 2 */
-  2, 0x13, 0x87, /* Power up the MADC divider with value 7 */
-  2, 0x14, 0x80, /* Program the OSR of ADC to 128 */
-  2, 0x3d, 0x01, /* Select ADC PRB_R1 */
-  0 // sentinel
+static const uint8_t conf_data_unmute[] = {
+// reg, data,
+  0x00, 0x00, /* Select Page 0 */
+  0x51, 0xc0, /* Power up Left and Right ADC Channels */
+  0x52, 0x00, /* Unmute Left and Right ADC Digital Volume Control */
 };
 
-static const uint8_t conf_data_routing[] = {
-  2, 0x00, 0x01, /* Select Page 1 */
-  2, 0x01, 0x08, /* Disable Internal Crude AVdd in presence of external AVdd supply or before powering up internal AVdd LDO*/
-  2, 0x02, 0x01, /* Enable Master Analog Power Control */
-  2, 0x7b, 0x01, /* Set the REF charging time to 40ms */
-  2, 0x14, 0x25, /* HP soft stepping settings for optimal pop performance at power up Rpop used is 6k with N = 6 and soft step = 20usec. This should work with 47uF coupling capacitor. Can try N=5,6 or 7 time constants as well. Trade-off delay vs “pop” sound. */
-  2, 0x0a, 0x33, /* Set the Input Common Mode to 0.9V and Output Common Mode for Headphone to 1.65V */
-
-  2, 0x3d, 0x00, /* Select ADC PTM_R4 */
-  2, 0x47, 0x32, /* Set MicPGA startup delay to 3.1ms */
-  2, 0x7b, 0x01, /* Set the REF charging time to 40ms */
-  2, 0x34, 0x10, /* Route IN2L to LEFT_P with 10K */
-  2, 0x36, 0x10, /* Route IN2R to LEFT_N with 10K */
-  2, 0x37, 0x04, /* Route IN3R to RIGHT_P with 10K */
-  2, 0x39, 0x04, /* Route IN3L to RIGHT_N with 10K */
-  2, 0x3b, 0, /* Unmute Left MICPGA, Gain selection of 32dB to make channel gain 0dB */
-  2, 0x3c, 0, /* Unmute Right MICPGA, Gain selection of 32dB to make channel gain 0dB */
-  0 // sentinel
+static const uint8_t conf_data_ch3_select[] = {
+// reg, data,
+  0x00, 0x01, /* Select Page 1 */
+  0x37, 0x04, /* Route IN3R to RIGHT_P with input impedance of 10K */
+  0x39, 0x04, /* Route IN3L to RIGHT_N with input impedance of 10K */
 };
 
-const uint8_t conf_data_unmute[] = {
-  2, 0x00, 0x00, /* Select Page 0 */
-  2, 0x51, 0xc0, /* Power up Left and Right ADC Channels */
-  2, 0x52, 0x00, /* Unmute Left and Right ADC Digital Volume Control */    
-  0 // sentinel
+static const uint8_t conf_data_ch1_select[] = {
+// reg, data,
+  0x00, 0x01, /* Select Page 1 */
+  0x37, 0x40, /* Route IN1R to RIGHT_P with input impedance of 10K */
+  0x39, 0x10, /* Route IN1L to RIGHT_N with input impedance of 10K */
 };
 
-static void
+static inline void
 tlv320aic3204_bulk_write(const uint8_t *buf, int len)
 {
-  int addr = AIC3204_ADDR;
-  i2cAcquireBus(&I2CD1);
-  (void)i2cMasterTransmitTimeout(&I2CD1, addr, buf, len, NULL, 0, 1000);
-  i2cReleaseBus(&I2CD1);
+  (void)i2cMasterTransmitTimeout(&I2CD1, AIC3204_ADDR, buf, len, NULL, 0, 1000);
 }
 
 #if 0
@@ -109,49 +113,32 @@ tlv320aic3204_read(uint8_t d0)
 #endif
 
 static void
-tlv320aic3204_config(const uint8_t *data)
+tlv320aic3204_config(const uint8_t *data, int len)
 {
-  const uint8_t *p = data;
-  while (*p) {
-    uint8_t len = *p++;
-    tlv320aic3204_bulk_write(p, len);
-    p += len;
-  }
+  i2cAcquireBus(&I2CD1);
+  for (;len--;data+=2)
+    tlv320aic3204_bulk_write(data, 2);
+  i2cReleaseBus(&I2CD1);
 }
 
 void tlv320aic3204_init(void)
 {
-  tlv320aic3204_config(conf_data_pll);
-  tlv320aic3204_config(conf_data_clk);
-  tlv320aic3204_config(conf_data_routing);
+  tlv320aic3204_config(conf_data, sizeof(conf_data)/2);
   wait_ms(40);
-  tlv320aic3204_config(conf_data_unmute);
+  tlv320aic3204_config(conf_data_unmute, sizeof(conf_data_unmute)/2);
 }
 
 void tlv320aic3204_select(int channel)
 {
-    const uint8_t ch3[] = {
-        2, 0x00, 0x01, /* Select Page 1 */
-        2, 0x37, 0x04, /* Route IN3R to RIGHT_P with input impedance of 10K */
-        2, 0x39, 0x04, /* Route IN3L to RIGHT_N with input impedance of 10K */    
-        0 // sentinel
-    };
-    const uint8_t ch1[] = {
-        2, 0x00, 0x01, /* Select Page 1 */
-        2, 0x37, 0x40, /* Route IN1R to RIGHT_P with input impedance of 10K */
-        2, 0x39, 0x10, /* Route IN1L to RIGHT_N with input impedance of 10K */    
-        0 // sentinel
-    };
-    tlv320aic3204_config(channel ? ch1 : ch3);
+  tlv320aic3204_config(channel ? conf_data_ch1_select : conf_data_ch3_select, sizeof(conf_data_ch3_select)/2);
 }
 
 void tlv320aic3204_set_gain(int lgain, int rgain)
 {
-    uint8_t data[] = {
-        2, 0x00, 0x01, /* Select Page 1 */
-        2, 0x3b, lgain, /* Unmute Left MICPGA, set gain */
-        2, 0x3c, rgain, /* Unmute Right MICPGA, set gain */    
-        0 // sentinel
-    };
-    tlv320aic3204_config(data);
+  uint8_t data[] = {
+    0x00, 0x01, /* Select Page 1 */
+    0x3b, lgain, /* Unmute Left MICPGA, set gain */
+    0x3c, rgain, /* Unmute Right MICPGA, set gain */
+  };
+  tlv320aic3204_config(data, sizeof(data)/2);
 }

--- a/ui.c
+++ b/ui.c
@@ -1358,7 +1358,7 @@ menu_item_modify_attribute(const menuitem_t *menu, int item,
       *fg = config.menu_normal_color;
     }
   } else if (menu == menu_stimulus) {
-    if (item == 5 /* PAUSE */ && !sweep_enabled) {
+    if (item == 5 /* PAUSE */ && !(sweep_mode&SWEEP_MODE_ENABLED)) {
       *bg = DEFAULT_MENU_TEXT_COLOR;
       *fg = config.menu_normal_color;
     }
@@ -2131,7 +2131,7 @@ touch_lever_mode_select(void)
     select_lever_mode(touch_x < FREQUENCIES_XPOS2 ? LM_CENTER : LM_SPAN);
     return TRUE;
   }
-  if (touch_y < 15) {
+  if (touch_y < 25) {
     if (touch_x < FREQUENCIES_XPOS2 && get_electrical_delay() != 0.0) {
       select_lever_mode(LM_EDELAY);
     } else 

--- a/ui.c
+++ b/ui.c
@@ -212,7 +212,7 @@ touch_measure_y(void)
   palSetPad(GPIOA, 6);
 
   chThdSleepMilliseconds(2);
-  v = adc_single_read(ADC1, ADC_CHSELR_CHSEL7);
+  v = adc_single_read(ADC_CHSELR_CHSEL7);
   //chThdSleepMilliseconds(2);
   //v += adc_single_read(ADC1, ADC_CHSELR_CHSEL7);
   return v;
@@ -232,7 +232,7 @@ touch_measure_x(void)
   palClearPad(GPIOA, 7);
 
   chThdSleepMilliseconds(2);
-  v = adc_single_read(ADC1, ADC_CHSELR_CHSEL6);
+  v = adc_single_read(ADC_CHSELR_CHSEL6);
   //chThdSleepMilliseconds(2);
   //v += adc_single_read(ADC1, ADC_CHSELR_CHSEL6);
   return v;
@@ -255,14 +255,14 @@ void
 touch_start_watchdog(void)
 {
   touch_prepare_sense();
-  adc_start_analog_watchdogd(ADC1, ADC_CHSELR_CHSEL7);
+  adc_start_analog_watchdogd(ADC_CHSELR_CHSEL7);
 }
 
 static int
 touch_status(void)
 {
   touch_prepare_sense();
-  return adc_single_read(ADC1, ADC_CHSELR_CHSEL7) > TOUCH_THRESHOLD;
+  return adc_single_read(ADC_CHSELR_CHSEL7) > TOUCH_THRESHOLD;
 }
 
 static int
@@ -302,7 +302,7 @@ touch_cal_exec(void)
 {
   int x1, x2, y1, y2;
   
-  adc_stop(ADC1);
+  adc_stop();
   setForegroundColor(DEFAULT_FG_COLOR);
   setBackgroundColor(DEFAULT_BG_COLOR);
   clearScreen();
@@ -338,7 +338,7 @@ touch_draw_test(void)
   int x0, y0;
   int x1, y1;
   
-  adc_stop(ADC1);
+  adc_stop();
 
   setForegroundColor(DEFAULT_FG_COLOR);
   setBackgroundColor(DEFAULT_BG_COLOR);
@@ -372,7 +372,7 @@ void
 show_version(void)
 {
   int x = 5, y = 5;
-  adc_stop(ADC1);
+  adc_stop();
   setForegroundColor(DEFAULT_FG_COLOR);
   setBackgroundColor(DEFAULT_BG_COLOR);
 
@@ -404,7 +404,7 @@ show_version(void)
 void
 enter_dfu(void)
 {
-  adc_stop(ADC1);
+  adc_stop();
 
   int x = 5, y = 5;
   setForegroundColor(DEFAULT_FG_COLOR);
@@ -2003,7 +2003,7 @@ static void
 ui_process_keypad(void)
 {
   int status;
-  adc_stop(ADC1);
+  adc_stop();
 
   kp_index = 0;
   while (TRUE) {
@@ -2145,7 +2145,7 @@ static
 void ui_process_touch(void)
 {
 //  awd_count++;
-  adc_stop(ADC1);
+  adc_stop();
 
   int status = touch_check();
   if (status == EVT_TOUCH_PRESSED || status == EVT_TOUCH_DOWN) {

--- a/ui.c
+++ b/ui.c
@@ -1358,7 +1358,7 @@ menu_item_modify_attribute(const menuitem_t *menu, int item,
       *fg = config.menu_normal_color;
     }
   } else if (menu == menu_stimulus) {
-    if (item == 5 /* PAUSE */ && !(sweep_mode&SWEEP_MODE_ENABLED)) {
+    if (item == 5 /* PAUSE */ && !sweep_enabled) {
       *bg = DEFAULT_MENU_TEXT_COLOR;
       *fg = config.menu_normal_color;
     }

--- a/ui.c
+++ b/ui.c
@@ -367,30 +367,21 @@ touch_position(int *x, int *y)
   *y = (last_touch_y - config.touch_cal[1]) * 16 / config.touch_cal[3];
 }
 
-
 void
 show_version(void)
 {
-  int x = 5, y = 5;
+  int x = 5, y = 5, i = 0;
   adc_stop();
   setForegroundColor(DEFAULT_FG_COLOR);
   setBackgroundColor(DEFAULT_BG_COLOR);
 
   clearScreen();
-  ili9341_drawstring_size(BOARD_NAME, x, y, 4);
-  y += 25;
-
-  ili9341_drawstring("2016-2020 Copyright @edy555", x, y += 10);
-  ili9341_drawstring("Licensed under GPL. See: https://github.com/ttrftech/NanoVNA", x, y += 10);
-  ili9341_drawstring("Version: " VERSION, x, y += 10);
-  ili9341_drawstring("Build Time: " __DATE__ " - " __TIME__, x, y += 10);
-  y += 5;
-  ili9341_drawstring("Kernel: " CH_KERNEL_VERSION, x, y += 10);
-  ili9341_drawstring("Compiler: " PORT_COMPILER_NAME, x, y += 10);
-  ili9341_drawstring("Architecture: " PORT_ARCHITECTURE_NAME " Core Variant: " PORT_CORE_VARIANT_NAME, x, y += 10);
-  ili9341_drawstring("Port Info: " PORT_INFO, x, y += 10);
-  ili9341_drawstring("Platform: " PLATFORM_NAME, x, y += 10);
-
+  uint16_t shift = 0b0000010000111110;
+  ili9341_drawstring_size(info_about[i++], x , y, 4);
+  while (info_about[i]){
+    do {shift>>=1; y+=5;} while (shift&1);
+    ili9341_drawstring(info_about[i++], x, y+=5);
+  }
   while (true) {
     if (touch_check() == EVT_TOUCH_PRESSED)
       break;

--- a/ui.c
+++ b/ui.c
@@ -1358,7 +1358,7 @@ menu_item_modify_attribute(const menuitem_t *menu, int item,
       *fg = config.menu_normal_color;
     }
   } else if (menu == menu_stimulus) {
-    if (item == 5 /* PAUSE */ && !sweep_enabled) {
+    if (item == 5 /* PAUSE */ && !(sweep_mode&SWEEP_ENABLE)) {
       *bg = DEFAULT_MENU_TEXT_COLOR;
       *fg = config.menu_normal_color;
     }


### PR DESCRIPTION
* Big work around si5351 generator
* si5351.c and si5351.h
Improve sweep speed about 60%
Remove all hack for si5351
Reduce code size
Fix integer overflow on big freq values
Fix rounding errors
Cleanup and optimize  code
Add comments, fix definitions

 * Others:
 move marker_tracking variable to ui config
 move some definition to correct place
 reduce tlv320aic3204 code size
 Speedup marker move from lever (BUTTON_REPEAT_TICKS = 625)

 * mcuconf.h
Set I2C bus clock to SYSCLK (more fast)
Apply 400kHz bus I2C clock timings for 8MHz and 48Mhz clock

 * main.c
Remove and reset some variables
