### PR TITLE
Fix screen artifacts, change start/stop or center/span mode set, remove Mutex use

### DIFF
--- a/chconf.h
+++ b/chconf.h
@@ -183,7 +183,7 @@
  *
  * @note    The default is @p TRUE.
  */
-#define CH_CFG_USE_MUTEXES                  TRUE
+#define CH_CFG_USE_MUTEXES                  FALSE
 
 /**
  * @brief   Enables recursive behavior on mutexes.

--- a/dsp.c
+++ b/dsp.c
@@ -41,57 +41,48 @@ const int16_t sincos_tbl[48][2] = {
   {-24636, -21605 }, {-32698,  -2143 }, {-27246,  18205 }, {-10533,  31029 }
 };
 
-int64_t acc_samp_s;
-int64_t acc_samp_c;
-int64_t acc_ref_s;
-int64_t acc_ref_c;
+int32_t acc_samp_s;
+int32_t acc_samp_c;
+int32_t acc_ref_s;
+int32_t acc_ref_c;
 
 void
 dsp_process(int16_t *capture, size_t length)
 {
+  uint32_t *p = (uint32_t*)capture;
+  uint32_t len = length / 2;
   uint32_t i;
-#if 1
-  acc_samp_s = 0;
-  acc_samp_c = 0;
-  acc_ref_s = 0;
-  acc_ref_c = 0;
-  for (i = 0; i < length; i+=2) {
-    int32_t ref = capture[i+0];
-    int32_t smp = capture[i+1];
+  int32_t samp_s = 0;
+  int32_t samp_c = 0;
+  int32_t ref_s = 0;
+  int32_t ref_c = 0;
+
+  for (i = 0; i < len; i++) {
+    uint32_t sr = *p++;
+    int16_t ref = sr & 0xffff;
+    int16_t smp = (sr>>16) & 0xffff;
 #ifdef ENABLED_DUMP
     ref_buf[i] = ref;
     samp_buf[i] = smp;
 #endif
-    int32_t s = ((int16_t *)sincos_tbl)[i+0];
-    int32_t c = ((int16_t *)sincos_tbl)[i+1];
-    acc_samp_s += (smp * s);
-    acc_samp_c += (smp * c);
-    acc_ref_s  += (ref * s);
-    acc_ref_c  += (ref * c);
-  }
-#else
-  uint32_t len = length / 2;
-  int64_t samp_s = 0;
-  int64_t samp_c = 0;
-  int64_t ref_s = 0;
-  int64_t ref_c = 0;
-  //        HI  LO
-  int32_t *cos_sin = (int32_t *)sincos_tbl;
-  int32_t *ref_smp = (int32_t *)capture;
-  for (i = 0; i < len; i++) {
-    //
-    samp_s = __SMLALBB(*ref_smp, *cos_sin, samp_s); // samp_s+= smp * sin
-    samp_c = __SMLALBT(*ref_smp, *cos_sin, samp_c); // samp_c+= smp * cos
-    ref_s  = __SMLALTB(*ref_smp, *cos_sin, ref_s);  // ref_s += ref * sin
-    ref_c  = __SMLALTT(*ref_smp, *cos_sin, ref_c);  // ref_s += ref * cos
-    ref_smp++;
-    cos_sin++;
+    int32_t s = sincos_tbl[i][0];
+    int32_t c = sincos_tbl[i][1];
+    samp_s += smp * s / 16;
+    samp_c += smp * c / 16;
+    ref_s += ref * s / 16;
+    ref_c += ref * c / 16;
+#if 0
+    uint32_t sc = *(uint32_t)&sincos_tbl[i];
+    samp_s = __SMLABB(sr, sc, samp_s);
+    samp_c = __SMLABT(sr, sc, samp_c);
+    ref_s = __SMLATB(sr, sc, ref_s);
+    ref_c = __SMLATT(sr, sc, ref_c);
+#endif
   }
   acc_samp_s = samp_s;
   acc_samp_c = samp_c;
-  acc_ref_s  = ref_s;
-  acc_ref_c  = ref_c;
-#endif
+  acc_ref_s = ref_s;
+  acc_ref_c = ref_c;
 }
 
 void
@@ -99,12 +90,12 @@ calculate_gamma(float gamma[2])
 {
 #if 1
   // calculate reflection coeff. by samp divide by ref
-  double rs = acc_ref_s;
-  double rc = acc_ref_c;
-  double rr = rs * rs + rc * rc;
+  float rs = acc_ref_s;
+  float rc = acc_ref_c;
+  float rr = rs * rs + rc * rc;
   //rr = sqrtf(rr) * 1e8;
-  double ss = acc_samp_s;
-  double sc = acc_samp_c;
+  float ss = acc_samp_s;
+  float sc = acc_samp_c;
   gamma[0] =  (sc * rc + ss * rs) / rr;
   gamma[1] =  (ss * rc - sc * rs) / rr;
 #elif 0

--- a/dsp.c
+++ b/dsp.c
@@ -41,48 +41,57 @@ const int16_t sincos_tbl[48][2] = {
   {-24636, -21605 }, {-32698,  -2143 }, {-27246,  18205 }, {-10533,  31029 }
 };
 
-int32_t acc_samp_s;
-int32_t acc_samp_c;
-int32_t acc_ref_s;
-int32_t acc_ref_c;
+int64_t acc_samp_s;
+int64_t acc_samp_c;
+int64_t acc_ref_s;
+int64_t acc_ref_c;
 
 void
 dsp_process(int16_t *capture, size_t length)
 {
-  uint32_t *p = (uint32_t*)capture;
-  uint32_t len = length / 2;
   uint32_t i;
-  int32_t samp_s = 0;
-  int32_t samp_c = 0;
-  int32_t ref_s = 0;
-  int32_t ref_c = 0;
-
-  for (i = 0; i < len; i++) {
-    uint32_t sr = *p++;
-    int16_t ref = sr & 0xffff;
-    int16_t smp = (sr>>16) & 0xffff;
+#if 1
+  acc_samp_s = 0;
+  acc_samp_c = 0;
+  acc_ref_s = 0;
+  acc_ref_c = 0;
+  for (i = 0; i < length; i+=2) {
+    int32_t ref = capture[i+0];
+    int32_t smp = capture[i+1];
 #ifdef ENABLED_DUMP
     ref_buf[i] = ref;
     samp_buf[i] = smp;
 #endif
-    int32_t s = sincos_tbl[i][0];
-    int32_t c = sincos_tbl[i][1];
-    samp_s += smp * s / 16;
-    samp_c += smp * c / 16;
-    ref_s += ref * s / 16;
-    ref_c += ref * c / 16;
-#if 0
-    uint32_t sc = *(uint32_t)&sincos_tbl[i];
-    samp_s = __SMLABB(sr, sc, samp_s);
-    samp_c = __SMLABT(sr, sc, samp_c);
-    ref_s = __SMLATB(sr, sc, ref_s);
-    ref_c = __SMLATT(sr, sc, ref_c);
-#endif
+    int32_t s = ((int16_t *)sincos_tbl)[i+0];
+    int32_t c = ((int16_t *)sincos_tbl)[i+1];
+    acc_samp_s += (smp * s);
+    acc_samp_c += (smp * c);
+    acc_ref_s  += (ref * s);
+    acc_ref_c  += (ref * c);
+  }
+#else
+  uint32_t len = length / 2;
+  int64_t samp_s = 0;
+  int64_t samp_c = 0;
+  int64_t ref_s = 0;
+  int64_t ref_c = 0;
+  //        HI  LO
+  int32_t *cos_sin = (int32_t *)sincos_tbl;
+  int32_t *ref_smp = (int32_t *)capture;
+  for (i = 0; i < len; i++) {
+    //
+    samp_s = __SMLALBB(*ref_smp, *cos_sin, samp_s); // samp_s+= smp * sin
+    samp_c = __SMLALBT(*ref_smp, *cos_sin, samp_c); // samp_c+= smp * cos
+    ref_s  = __SMLALTB(*ref_smp, *cos_sin, ref_s);  // ref_s += ref * sin
+    ref_c  = __SMLALTT(*ref_smp, *cos_sin, ref_c);  // ref_s += ref * cos
+    ref_smp++;
+    cos_sin++;
   }
   acc_samp_s = samp_s;
   acc_samp_c = samp_c;
-  acc_ref_s = ref_s;
-  acc_ref_c = ref_c;
+  acc_ref_s  = ref_s;
+  acc_ref_c  = ref_c;
+#endif
 }
 
 void
@@ -90,12 +99,12 @@ calculate_gamma(float gamma[2])
 {
 #if 1
   // calculate reflection coeff. by samp divide by ref
-  float rs = acc_ref_s;
-  float rc = acc_ref_c;
-  float rr = rs * rs + rc * rc;
+  double rs = acc_ref_s;
+  double rc = acc_ref_c;
+  double rr = rs * rs + rc * rc;
   //rr = sqrtf(rr) * 1e8;
-  float ss = acc_samp_s;
-  float sc = acc_samp_c;
+  double ss = acc_samp_s;
+  double sc = acc_samp_c;
   gamma[0] =  (sc * rc + ss * rs) / rr;
   gamma[1] =  (ss * rc - sc * rs) / rr;
 #elif 0

--- a/fft.h
+++ b/fft.h
@@ -68,8 +68,8 @@ static void fft256(float array[][2], const uint8_t dir) {
 			uint16_t j, k;
 			for (j = i, k = 0; j < i + halfsize; j++, k += tablestep) {
 				uint16_t l = j + halfsize;
-				float tpre =  array[l][real] * cos(2 * M_PI * k / 256) + array[l][imag] * sin(2 * M_PI * k / 256);
-				float tpim = -array[l][real] * sin(2 * M_PI * k / 256) + array[l][imag] * cos(2 * M_PI * k / 256);
+				float tpre =  array[l][real] * cos(2 * VNA_PI * k / 256) + array[l][imag] * sin(2 * VNA_PI * k / 256);
+				float tpim = -array[l][real] * sin(2 * VNA_PI * k / 256) + array[l][imag] * cos(2 * VNA_PI * k / 256);
 				array[l][real] = array[j][real] - tpre;
 				array[l][imag] = array[j][imag] - tpim;
 				array[j][real] += tpre;

--- a/ili9341.c
+++ b/ili9341.c
@@ -23,97 +23,97 @@
 
 uint16_t spi_buffer[SPI_BUFFER_SIZE];
 // Default foreground & background colors
-uint16_t foreground_color=DEFAULT_FG_COLOR;
-uint16_t background_color=DEFAULT_BG_COLOR;
+uint16_t foreground_color=0;
+uint16_t background_color=0;
 
 // Display width and height definition
-#define ILI9341_WIDTH		320
-#define ILI9341_HEIGHT		240
+#define ILI9341_WIDTH     320
+#define ILI9341_HEIGHT    240
 
 // Display commands list
-#define ILI9341_NOP							0x00
-#define ILI9341_SOFTWARE_RESET				0x01
-#define ILI9341_READ_IDENTIFICATION			0x04
-#define ILI9341_READ_STATUS					0x09
-#define ILI9341_READ_POWER_MODE				0x0A
-#define ILI9341_READ_MADCTL					0x0B
-#define ILI9341_READ_PIXEL_FORMAT			0x0C
-#define ILI9341_READ_IMAGE_FORMAT			0x0D
-#define ILI9341_READ_SIGNAL_MODE			0x0E
-#define ILI9341_READ_SELF_DIAGNOSTIC		0x0F
-#define ILI9341_SLEEP_IN					0x10
-#define ILI9341_SLEEP_OUT					0x11
-#define ILI9341_PARTIAL_MODE_ON				0x12
-#define ILI9341_NORMAL_DISPLAY_MODE_ON		0x13
-#define ILI9341_INVERSION_OFF				0x20
-#define ILI9341_INVERSION_ON				0x21
-#define ILI9341_GAMMA_SET					0x26
-#define ILI9341_DISPLAY_OFF					0x28
-#define ILI9341_DISPLAY_ON					0x29
-#define ILI9341_COLUMN_ADDRESS_SET			0x2A
-#define ILI9341_PAGE_ADDRESS_SET			0x2B
-#define ILI9341_MEMORY_WRITE				0x2C
-#define ILI9341_COLOR_SET					0x2D
-#define ILI9341_MEMORY_READ					0x2E
-#define ILI9341_PARTIAL_AREA				0x30
-#define ILI9341_VERTICAL_SCROLLING_DEF		0x33
-#define ILI9341_TEARING_LINE_OFF			0x34
-#define ILI9341_TEARING_LINE_ON				0x35
-#define ILI9341_MEMORY_ACCESS_CONTROL		0x36
-#define ILI9341_VERTICAL_SCROLLING			0x37
-#define ILI9341_IDLE_MODE_OFF				0x38
-#define ILI9341_IDLE_MODE_ON				0x39
-#define ILI9341_PIXEL_FORMAT_SET			0x3A
-#define ILI9341_WRITE_MEMORY_CONTINUE		0x3C
-#define ILI9341_READ_MEMORY_CONTINUE		0x3E
-#define ILI9341_SET_TEAR_SCANLINE			0x44
-#define ILI9341_GET_SCANLINE				0x45
-#define ILI9341_WRITE_BRIGHTNESS 			0x51
-#define ILI9341_READ_BRIGHTNESS				0x52
-#define ILI9341_WRITE_CTRL_DISPLAY			0x53
-#define ILI9341_READ_CTRL_DISPLAY			0x54
-#define ILI9341_WRITE_CA_BRIGHTNESS			0x55
-#define ILI9341_READ_CA_BRIGHTNESS			0x56
-#define ILI9341_WRITE_CA_MIN_BRIGHTNESS		0x5E
-#define ILI9341_READ_CA_MIN_BRIGHTNESS		0x5F
-#define ILI9341_READ_ID1					0xDA
-#define ILI9341_READ_ID2					0xDB
-#define ILI9341_READ_ID3					0xDC
-#define ILI9341_RGB_INTERFACE_CONTROL		0xB0
-#define ILI9341_FRAME_RATE_CONTROL_1		0xB1
-#define ILI9341_FRAME_RATE_CONTROL_2		0xB2
-#define ILI9341_FRAME_RATE_CONTROL_3		0xB3
-#define ILI9341_DISPLAY_INVERSION_CONTROL	0xB4
-#define ILI9341_BLANKING_PORCH_CONTROL		0xB5
-#define ILI9341_DISPLAY_FUNCTION_CONTROL	0xB6
-#define ILI9341_ENTRY_MODE_SET				0xB7
-#define ILI9341_BACKLIGHT_CONTROL_1			0xB8
-#define ILI9341_BACKLIGHT_CONTROL_2			0xB9
-#define ILI9341_BACKLIGHT_CONTROL_3			0xBA
-#define ILI9341_BACKLIGHT_CONTROL_4			0xBB
-#define ILI9341_BACKLIGHT_CONTROL_5			0xBC
-#define ILI9341_BACKLIGHT_CONTROL_7			0xBE
-#define ILI9341_BACKLIGHT_CONTROL_8			0xBF
-#define ILI9341_POWER_CONTROL_1				0xC0
-#define ILI9341_POWER_CONTROL_2				0xC1
-#define ILI9341_VCOM_CONTROL_1				0xC5
-#define ILI9341_VCOM_CONTROL_2				0xC7
-#define ILI9341_POWERA						0xCB
-#define ILI9341_POWERB						0xCF
-#define ILI9341_NV_MEMORY_WRITE				0xD0
-#define ILI9341_NV_PROTECTION_KEY			0xD1
-#define ILI9341_NV_STATUS_READ				0xD2
-#define ILI9341_READ_ID4					0xD3
-#define ILI9341_POSITIVE_GAMMA_CORRECTION	0xE0
-#define ILI9341_NEGATIVE_GAMMA_CORRECTION	0xE1
-#define ILI9341_DIGITAL_GAMMA_CONTROL_1		0xE2
-#define ILI9341_DIGITAL_GAMMA_CONTROL_2		0xE3
-#define ILI9341_DTCA						0xE8
-#define ILI9341_DTCB						0xEA
-#define ILI9341_POWER_SEQ					0xED
-#define ILI9341_3GAMMA_EN					0xF2
-#define ILI9341_INTERFACE_CONTROL			0xF6
-#define ILI9341_PUMP_RATIO_CONTROL			0xF7
+#define ILI9341_NOP                        0x00
+#define ILI9341_SOFTWARE_RESET             0x01
+#define ILI9341_READ_IDENTIFICATION        0x04
+#define ILI9341_READ_STATUS                0x09
+#define ILI9341_READ_POWER_MODE            0x0A
+#define ILI9341_READ_MADCTL                0x0B
+#define ILI9341_READ_PIXEL_FORMAT          0x0C
+#define ILI9341_READ_IMAGE_FORMAT          0x0D
+#define ILI9341_READ_SIGNAL_MODE           0x0E
+#define ILI9341_READ_SELF_DIAGNOSTIC       0x0F
+#define ILI9341_SLEEP_IN                   0x10
+#define ILI9341_SLEEP_OUT                  0x11
+#define ILI9341_PARTIAL_MODE_ON            0x12
+#define ILI9341_NORMAL_DISPLAY_MODE_ON     0x13
+#define ILI9341_INVERSION_OFF              0x20
+#define ILI9341_INVERSION_ON               0x21
+#define ILI9341_GAMMA_SET                  0x26
+#define ILI9341_DISPLAY_OFF                0x28
+#define ILI9341_DISPLAY_ON                 0x29
+#define ILI9341_COLUMN_ADDRESS_SET         0x2A
+#define ILI9341_PAGE_ADDRESS_SET           0x2B
+#define ILI9341_MEMORY_WRITE               0x2C
+#define ILI9341_COLOR_SET                  0x2D
+#define ILI9341_MEMORY_READ                0x2E
+#define ILI9341_PARTIAL_AREA               0x30
+#define ILI9341_VERTICAL_SCROLLING_DEF     0x33
+#define ILI9341_TEARING_LINE_OFF           0x34
+#define ILI9341_TEARING_LINE_ON            0x35
+#define ILI9341_MEMORY_ACCESS_CONTROL      0x36
+#define ILI9341_VERTICAL_SCROLLING         0x37
+#define ILI9341_IDLE_MODE_OFF              0x38
+#define ILI9341_IDLE_MODE_ON               0x39
+#define ILI9341_PIXEL_FORMAT_SET           0x3A
+#define ILI9341_WRITE_MEMORY_CONTINUE      0x3C
+#define ILI9341_READ_MEMORY_CONTINUE       0x3E
+#define ILI9341_SET_TEAR_SCANLINE          0x44
+#define ILI9341_GET_SCANLINE               0x45
+#define ILI9341_WRITE_BRIGHTNESS           0x51
+#define ILI9341_READ_BRIGHTNESS            0x52
+#define ILI9341_WRITE_CTRL_DISPLAY         0x53
+#define ILI9341_READ_CTRL_DISPLAY          0x54
+#define ILI9341_WRITE_CA_BRIGHTNESS        0x55
+#define ILI9341_READ_CA_BRIGHTNESS         0x56
+#define ILI9341_WRITE_CA_MIN_BRIGHTNESS    0x5E
+#define ILI9341_READ_CA_MIN_BRIGHTNESS     0x5F
+#define ILI9341_READ_ID1                   0xDA
+#define ILI9341_READ_ID2                   0xDB
+#define ILI9341_READ_ID3                   0xDC
+#define ILI9341_RGB_INTERFACE_CONTROL      0xB0
+#define ILI9341_FRAME_RATE_CONTROL_1       0xB1
+#define ILI9341_FRAME_RATE_CONTROL_2       0xB2
+#define ILI9341_FRAME_RATE_CONTROL_3       0xB3
+#define ILI9341_DISPLAY_INVERSION_CONTROL  0xB4
+#define ILI9341_BLANKING_PORCH_CONTROL     0xB5
+#define ILI9341_DISPLAY_FUNCTION_CONTROL   0xB6
+#define ILI9341_ENTRY_MODE_SET             0xB7
+#define ILI9341_BACKLIGHT_CONTROL_1        0xB8
+#define ILI9341_BACKLIGHT_CONTROL_2        0xB9
+#define ILI9341_BACKLIGHT_CONTROL_3        0xBA
+#define ILI9341_BACKLIGHT_CONTROL_4        0xBB
+#define ILI9341_BACKLIGHT_CONTROL_5        0xBC
+#define ILI9341_BACKLIGHT_CONTROL_7        0xBE
+#define ILI9341_BACKLIGHT_CONTROL_8        0xBF
+#define ILI9341_POWER_CONTROL_1            0xC0
+#define ILI9341_POWER_CONTROL_2            0xC1
+#define ILI9341_VCOM_CONTROL_1             0xC5
+#define ILI9341_VCOM_CONTROL_2             0xC7
+#define ILI9341_POWERA                     0xCB
+#define ILI9341_POWERB                     0xCF
+#define ILI9341_NV_MEMORY_WRITE            0xD0
+#define ILI9341_NV_PROTECTION_KEY          0xD1
+#define ILI9341_NV_STATUS_READ             0xD2
+#define ILI9341_READ_ID4                   0xD3
+#define ILI9341_POSITIVE_GAMMA_CORRECTION  0xE0
+#define ILI9341_NEGATIVE_GAMMA_CORRECTION  0xE1
+#define ILI9341_DIGITAL_GAMMA_CONTROL_1    0xE2
+#define ILI9341_DIGITAL_GAMMA_CONTROL_2    0xE3
+#define ILI9341_DTCA                       0xE8
+#define ILI9341_DTCB                       0xEA
+#define ILI9341_POWER_SEQ                  0xED
+#define ILI9341_3GAMMA_EN                  0xF2
+#define ILI9341_INTERFACE_CONTROL          0xF6
+#define ILI9341_PUMP_RATIO_CONTROL         0xF7
 
 //
 // ILI9341_MEMORY_ACCESS_CONTROL registers
@@ -126,20 +126,20 @@ uint16_t background_color=DEFAULT_BG_COLOR;
 #define ILI9341_MADCTL_MH  0x04
 #define ILI9341_MADCTL_RGB 0x00
 
-#define DISPLAY_ROTATION_270	(ILI9341_MADCTL_MX | ILI9341_MADCTL_BGR)
-#define DISPLAY_ROTATION_90		(ILI9341_MADCTL_MY | ILI9341_MADCTL_BGR)
-#define DISPLAY_ROTATION_0		(ILI9341_MADCTL_MV | ILI9341_MADCTL_BGR)
-#define DISPLAY_ROTATION_180	(ILI9341_MADCTL_MX | ILI9341_MADCTL_MY | ILI9341_MADCTL_MV | ILI9341_MADCTL_BGR)
+#define DISPLAY_ROTATION_270   (ILI9341_MADCTL_MX | ILI9341_MADCTL_BGR)
+#define DISPLAY_ROTATION_90    (ILI9341_MADCTL_MY | ILI9341_MADCTL_BGR)
+#define DISPLAY_ROTATION_0     (ILI9341_MADCTL_MV | ILI9341_MADCTL_BGR)
+#define DISPLAY_ROTATION_180   (ILI9341_MADCTL_MX | ILI9341_MADCTL_MY | ILI9341_MADCTL_MV | ILI9341_MADCTL_BGR)
 
 //
 // Pin macros
 //
-#define RESET_ASSERT	palClearPad(GPIOA, 15)
-#define RESET_NEGATE	palSetPad(GPIOA, 15)
-#define CS_LOW			palClearPad(GPIOB, 6)
-#define CS_HIGH			palSetPad(GPIOB, 6)
-#define DC_CMD			palClearPad(GPIOB, 7)
-#define DC_DATA			palSetPad(GPIOB, 7)
+#define RESET_ASSERT  palClearPad(GPIOA, 15)
+#define RESET_NEGATE  palSetPad(GPIOA, 15)
+#define CS_LOW        palClearPad(GPIOB, 6)
+#define CS_HIGH       palSetPad(GPIOB, 6)
+#define DC_CMD        palClearPad(GPIOB, 7)
+#define DC_DATA       palSetPad(GPIOB, 7)
 
 //*****************************************************************************
 //********************************** SPI bus **********************************
@@ -159,17 +159,17 @@ uint16_t background_color=DEFAULT_BG_COLOR;
 
 // The RXNE flag is set depending on the FRXTH bit value in the SPIx_CR2 register:
 // • If FRXTH is set, RXNE goes high and stays high until the RXFIFO level is greater or equal to 1/4 (8-bit).
-#define SPI_RX_IS_NOT_EMPTY	(SPI1->SR&SPI_SR_RXNE)
+#define SPI_RX_IS_NOT_EMPTY  (SPI1->SR&SPI_SR_RXNE)
 #define SPI_RX_IS_EMPTY     (((SPI1->SR&SPI_SR_RXNE) == 0))
 
 // The TXE flag is set when transmission TXFIFO has enough space to store data to send.
 // 0: Tx buffer not empty, bit is cleared automatically when the TXFIFO level becomes greater than 1/2
 // 1: Tx buffer empty, flag goes high and stays high until the TXFIFO level is lower or equal to 1/2 of the FIFO depth
-#define SPI_TX_IS_NOT_EMPTY	(((SPI1->SR&(SPI_SR_TXE)) == 0))
+#define SPI_TX_IS_NOT_EMPTY  (((SPI1->SR&(SPI_SR_TXE)) == 0))
 #define SPI_TX_IS_EMPTY     (SPI1->SR&SPI_SR_TXE)
 
 // When BSY is set, it indicates that a data transfer is in progress on the SPI (the SPI bus is busy).
-#define SPI_IS_BUSY 		(SPI1->SR & SPI_SR_BSY)
+#define SPI_IS_BUSY     (SPI1->SR & SPI_SR_BSY)
 
 // SPI send data macros
 #define SPI_WRITE_8BIT(data)  *(__IO uint8_t*)(&SPI1->DR) = (uint8_t) data
@@ -180,11 +180,11 @@ uint16_t background_color=DEFAULT_BG_COLOR;
 
 #ifdef __USE_DISPLAY_DMA__
 static const stm32_dma_stream_t  *dmatx = STM32_DMA_STREAM(STM32_SPI_SPI1_TX_DMA_STREAM);
-static uint32_t txdmamode = STM32_DMA_CR_CHSEL(SPI1_TX_DMA_CHANNEL)		// Select SPI1 Tx DMA
-						| STM32_DMA_CR_PL(STM32_SPI_SPI1_DMA_PRIORITY)	// Set priority
-						| STM32_DMA_CR_DIR_M2P							// Memory to Spi
-						| STM32_DMA_CR_DMEIE							//
-						| STM32_DMA_CR_TEIE;
+static uint32_t txdmamode = STM32_DMA_CR_CHSEL(SPI1_TX_DMA_CHANNEL)    // Select SPI1 Tx DMA
+                        | STM32_DMA_CR_PL(STM32_SPI_SPI1_DMA_PRIORITY)  // Set priority
+                        | STM32_DMA_CR_DIR_M2P              // Memory to Spi
+                        | STM32_DMA_CR_DMEIE              //
+                        | STM32_DMA_CR_TEIE;
 
 static void spi_lld_serve_tx_interrupt(SPIDriver *spip, uint32_t flags) {
   (void)spip;
@@ -193,11 +193,11 @@ static void spi_lld_serve_tx_interrupt(SPIDriver *spip, uint32_t flags) {
 
 static const stm32_dma_stream_t  *dmarx = STM32_DMA_STREAM(STM32_SPI_SPI1_RX_DMA_STREAM);
 static uint32_t rxdmamode = STM32_DMA_CR_CHSEL(SPI1_RX_DMA_CHANNEL)
-        				| STM32_DMA_CR_PL(STM32_SPI_SPI1_DMA_PRIORITY)
-						| STM32_DMA_CR_DIR_P2M
-						| STM32_DMA_CR_TCIE
-						| STM32_DMA_CR_DMEIE
-						| STM32_DMA_CR_TEIE;
+                        | STM32_DMA_CR_PL(STM32_SPI_SPI1_DMA_PRIORITY)
+                        | STM32_DMA_CR_DIR_P2M
+                        | STM32_DMA_CR_TCIE
+                        | STM32_DMA_CR_DMEIE
+                        | STM32_DMA_CR_TEIE;
 
 static void spi_lld_serve_rx_interrupt(SPIDriver *spip, uint32_t flags) {
   (void)spip;
@@ -205,14 +205,14 @@ static void spi_lld_serve_rx_interrupt(SPIDriver *spip, uint32_t flags) {
 }
 
 static void dmaStreamFlush(uint32_t len){
-	while (len){
-		// DMA data transfer limited by 65535
-		uint16_t tx_size = len > 65535 ? 65535 : len;
-		dmaStreamSetTransactionSize(dmatx, tx_size);
-		dmaStreamEnable(dmatx);
-		len -= tx_size;
-		dmaWaitCompletion(dmatx);
-	}
+  while (len){
+    // DMA data transfer limited by 65535
+    uint16_t tx_size = len > 65535 ? 65535 : len;
+    dmaStreamSetTransactionSize(dmatx, tx_size);
+    dmaStreamEnable(dmatx);
+    len -= tx_size;
+    dmaWaitCompletion(dmatx);
+  }
 }
 #endif
 
@@ -221,13 +221,13 @@ static void spi_init(void)
   rccEnableSPI1(FALSE);
   SPI1->CR1 = 0;
   SPI1->CR1 = SPI_CR1_MSTR       // SPI is MASTER
-			| SPI_CR1_SSM        // Software slave management (The external NSS pin is free for other application uses)
-			| SPI_CR1_SSI;       // Internal slave select (This bit has an effect only when the SSM bit is set. Allow use NSS pin as I/O)
-            // | SPI_CR1_BR_1;   // Baud rate control
+            | SPI_CR1_SSM        // Software slave management (The external NSS pin is free for other application uses)
+            | SPI_CR1_SSI;       // Internal slave select (This bit has an effect only when the SSM bit is set. Allow use NSS pin as I/O)
+//          | SPI_CR1_BR_1;      // Baud rate control
 
   SPI1->CR2 = SPI_CR2_8BIT       // SPI data size, set to 8 bit
-			| SPI_CR2_FRXTH;     // SPI_SR_RXNE generated every 8 bit data
-//		    | SPI_CR2_SSOE;      //
+            | SPI_CR2_FRXTH;     // SPI_SR_RXNE generated every 8 bit data
+//          | SPI_CR2_SSOE;      //
 
 #ifdef __USE_DISPLAY_DMA__
   // Tx DMA init
@@ -238,7 +238,7 @@ static void spi_init(void)
   dmaStreamSetPeripheral(dmarx, &SPI1->DR);
   // Enable DMA on SPI
   SPI1->CR2|= SPI_CR2_TXDMAEN    // Tx DMA enable
-		   |  SPI_CR2_RXDMAEN;   // Rx DMA enable
+           |  SPI_CR2_RXDMAEN;   // Rx DMA enable
 #endif
   SPI1->CR1|= SPI_CR1_SPE;       //SPI enable
 }
@@ -246,166 +246,166 @@ static void spi_init(void)
 // Disable inline for this function
 static void __attribute__ ((noinline)) send_command(uint8_t cmd, uint8_t len, const uint8_t *data)
 {
-	CS_LOW;
-	//	while (SPI_TX_IS_NOT_EMPTY);
-	DC_CMD;
-	SPI_WRITE_8BIT(cmd);
-	// Need wait transfer complete and set data bit
-	while (SPI_IS_BUSY);
-	// Send command data (if need)
-	DC_DATA;
-	while (len-- > 0) {
-		while (SPI_TX_IS_NOT_EMPTY);
-		SPI_WRITE_8BIT(*data++);
-	}
-	//CS_HIGH;
+  CS_LOW;
+  //while (SPI_TX_IS_NOT_EMPTY);
+  DC_CMD;
+  SPI_WRITE_8BIT(cmd);
+  // Need wait transfer complete and set data bit
+  while (SPI_IS_BUSY);
+  // Send command data (if need)
+  DC_DATA;
+  while (len-- > 0) {
+    while (SPI_TX_IS_NOT_EMPTY);
+    SPI_WRITE_8BIT(*data++);
+  }
+  //CS_HIGH;
 }
 
 static const uint8_t ili9341_init_seq[] = {
-		// cmd, len, data...,
-	    // SW reset
-		ILI9341_SOFTWARE_RESET, 0,
-		// display off
-		ILI9341_DISPLAY_OFF, 0,
-		// Power control B
-		ILI9341_POWERB, 3, 0x00, 0x83, 0x30,
-		// Power on sequence control
-		ILI9341_POWER_SEQ, 4, 0x64, 0x03, 0x12, 0x81,
-		//ILI9341_POWER_SEQ, 4, 0x55, 0x01, 0x23, 0x01,
-		// Driver timing control A
-		ILI9341_DTCA, 3, 0x85, 0x01, 0x79,
-		//ILI9341_DTCA, 3, 0x84, 0x11, 0x7a,
-		// Power control A
-		ILI9341_POWERA, 5, 0x39, 0x2C, 0x00, 0x34, 0x02,
-		// Pump ratio control
-		ILI9341_PUMP_RATIO_CONTROL, 1, 0x20,
-		// Driver timing control B
-		ILI9341_DTCB, 2, 0x00, 0x00,
-		// POWER_CONTROL_1
-		ILI9341_POWER_CONTROL_1, 1, 0x26,
-		// POWER_CONTROL_2
-		ILI9341_POWER_CONTROL_2, 1, 0x11,
-		// VCOM_CONTROL_1
-		ILI9341_VCOM_CONTROL_1, 2, 0x35, 0x3E,
-		// VCOM_CONTROL_2
-		ILI9341_VCOM_CONTROL_2, 1, 0xBE,
-		// MEMORY_ACCESS_CONTROL
-		//ILI9341_MEMORY_ACCESS_CONTROL, 1, 0x48, // portlait
-		ILI9341_MEMORY_ACCESS_CONTROL, 1, DISPLAY_ROTATION_0, // landscape
-		// COLMOD_PIXEL_FORMAT_SET : 16 bit pixel
-		ILI9341_PIXEL_FORMAT_SET, 1, 0x55,
-		// Frame Rate
-		ILI9341_FRAME_RATE_CONTROL_1, 2, 0x00, 0x1B,
-		// Gamma Function Disable
-		ILI9341_3GAMMA_EN, 1, 0x08,
-		// gamma set for curve 01/2/04/08
-		ILI9341_GAMMA_SET, 1, 0x01,
-		// positive gamma correction
-//		ILI9341_POSITIVE_GAMMA_CORRECTION, 15, 0x1F,  0x1A,  0x18,  0x0A,  0x0F,  0x06,  0x45,  0x87,  0x32,  0x0A,  0x07,  0x02,  0x07, 0x05,  0x00,
-		// negativ gamma correction
-//		ILI9341_NEGATIVE_GAMMA_CORRECTION, 15, 0x00,  0x25,  0x27,  0x05,  0x10,  0x09,  0x3A,  0x78,  0x4D,  0x05,  0x18,  0x0D,  0x38, 0x3A,  0x1F,
-		// Column Address Set
-//		ILI9341_COLUMN_ADDRESS_SET, 4, 0x00, 0x00, 0x01, 0x3f, // width 320
-	    // Page Address Set
-//		ILI9341_PAGE_ADDRESS_SET, 4, 0x00, 0x00, 0x00, 0xef,   // height 240
-		// entry mode
-		ILI9341_ENTRY_MODE_SET, 1, 0x06,
-		// display function control
-		ILI9341_DISPLAY_FUNCTION_CONTROL, 4, 0x0A, 0x82, 0x27, 0x00,
-		// Interface Control (set WEMODE=0)
-		ILI9341_INTERFACE_CONTROL, 3, 0x00, 0x00, 0x00,
-		// control display
-		//ILI9341_WRITE_CTRL_DISPLAY, 1, 0x0c,
-		// diaplay brightness
-		//ILI9341_WRITE_BRIGHTNESS, 1, 0xff,
-		// sleep out
-		ILI9341_SLEEP_OUT, 0,
-		// display on
-		ILI9341_DISPLAY_ON, 0,
-		0 // sentinel
+  // cmd, len, data...,
+  // SW reset
+  ILI9341_SOFTWARE_RESET, 0,
+  // display off
+  ILI9341_DISPLAY_OFF, 0,
+  // Power control B
+  ILI9341_POWERB, 3, 0x00, 0x83, 0x30,
+  // Power on sequence control
+  ILI9341_POWER_SEQ, 4, 0x64, 0x03, 0x12, 0x81,
+  //ILI9341_POWER_SEQ, 4, 0x55, 0x01, 0x23, 0x01,
+  // Driver timing control A
+  ILI9341_DTCA, 3, 0x85, 0x01, 0x79,
+  //ILI9341_DTCA, 3, 0x84, 0x11, 0x7a,
+  // Power control A
+  ILI9341_POWERA, 5, 0x39, 0x2C, 0x00, 0x34, 0x02,
+  // Pump ratio control
+  ILI9341_PUMP_RATIO_CONTROL, 1, 0x20,
+  // Driver timing control B
+  ILI9341_DTCB, 2, 0x00, 0x00,
+  // POWER_CONTROL_1
+  ILI9341_POWER_CONTROL_1, 1, 0x26,
+  // POWER_CONTROL_2
+  ILI9341_POWER_CONTROL_2, 1, 0x11,
+  // VCOM_CONTROL_1
+  ILI9341_VCOM_CONTROL_1, 2, 0x35, 0x3E,
+  // VCOM_CONTROL_2
+  ILI9341_VCOM_CONTROL_2, 1, 0xBE,
+  // MEMORY_ACCESS_CONTROL
+  //ILI9341_MEMORY_ACCESS_CONTROL, 1, 0x48, // portlait
+  ILI9341_MEMORY_ACCESS_CONTROL, 1, DISPLAY_ROTATION_0, // landscape
+  // COLMOD_PIXEL_FORMAT_SET : 16 bit pixel
+  ILI9341_PIXEL_FORMAT_SET, 1, 0x55,
+  // Frame Rate
+  ILI9341_FRAME_RATE_CONTROL_1, 2, 0x00, 0x1B,
+  // Gamma Function Disable
+  ILI9341_3GAMMA_EN, 1, 0x08,
+  // gamma set for curve 01/2/04/08
+  ILI9341_GAMMA_SET, 1, 0x01,
+  // positive gamma correction
+//ILI9341_POSITIVE_GAMMA_CORRECTION, 15, 0x1F,  0x1A,  0x18,  0x0A,  0x0F,  0x06,  0x45,  0x87,  0x32,  0x0A,  0x07,  0x02,  0x07, 0x05,  0x00,
+  // negativ gamma correction
+//ILI9341_NEGATIVE_GAMMA_CORRECTION, 15, 0x00,  0x25,  0x27,  0x05,  0x10,  0x09,  0x3A,  0x78,  0x4D,  0x05,  0x18,  0x0D,  0x38, 0x3A,  0x1F,
+  // Column Address Set
+//ILI9341_COLUMN_ADDRESS_SET, 4, 0x00, 0x00, 0x01, 0x3f, // width 320
+  // Page Address Set
+//ILI9341_PAGE_ADDRESS_SET, 4, 0x00, 0x00, 0x00, 0xef,   // height 240
+  // entry mode
+  ILI9341_ENTRY_MODE_SET, 1, 0x06,
+  // display function control
+  ILI9341_DISPLAY_FUNCTION_CONTROL, 4, 0x0A, 0x82, 0x27, 0x00,
+  // Interface Control (set WEMODE=0)
+  ILI9341_INTERFACE_CONTROL, 3, 0x00, 0x00, 0x00,
+  // control display
+  //ILI9341_WRITE_CTRL_DISPLAY, 1, 0x0c,
+  // diaplay brightness
+  //ILI9341_WRITE_BRIGHTNESS, 1, 0xff,
+  // sleep out
+  ILI9341_SLEEP_OUT, 0,
+  // display on
+  ILI9341_DISPLAY_ON, 0,
+  0 // sentinel
 };
 
 void ili9341_init(void)
 {
-    spi_init();
-    DC_DATA;
-    RESET_ASSERT;
-    chThdSleepMilliseconds(10);
-    RESET_NEGATE;
-    const uint8_t *p;
-    for (p = ili9341_init_seq; *p; ) {
-        send_command(p[0], p[1], &p[2]);
-        p += 2 + p[1];
-        chThdSleepMilliseconds(5);
-    }
+  spi_init();
+  DC_DATA;
+  RESET_ASSERT;
+  chThdSleepMilliseconds(10);
+  RESET_NEGATE;
+  const uint8_t *p;
+  for (p = ili9341_init_seq; *p; ) {
+    send_command(p[0], p[1], &p[2]);
+    p += 2 + p[1];
+    chThdSleepMilliseconds(5);
+  }
 }
 
 #ifndef __USE_DISPLAY_DMA__
 void ili9341_fill(int x, int y, int w, int h, int color)
 {
-//	uint8_t xx[4] = { x >> 8, x, (x+w-1) >> 8, (x+w-1) };
-//	uint8_t yy[4] = { y >> 8, y, (y+h-1) >> 8, (y+h-1) };
-	uint32_t xx = __REV16(x|((x+w-1)<<16));
-	uint32_t yy = __REV16(y|((y+h-1)<<16));
-	send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
-	send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
-	send_command(ILI9341_MEMORY_WRITE, 0, NULL);
-	int32_t len = w * h;
-	while (len-- > 0){
-		while (SPI_TX_IS_NOT_EMPTY);
-		SPI_WRITE_16BIT(color);
-	}
+//uint8_t xx[4] = { x >> 8, x, (x+w-1) >> 8, (x+w-1) };
+//uint8_t yy[4] = { y >> 8, y, (y+h-1) >> 8, (y+h-1) };
+  uint32_t xx = __REV16(x|((x+w-1)<<16));
+  uint32_t yy = __REV16(y|((y+h-1)<<16));
+  send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
+  send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
+  send_command(ILI9341_MEMORY_WRITE, 0, NULL);
+  int32_t len = w * h;
+  while (len-- > 0){
+    while (SPI_TX_IS_NOT_EMPTY);
+  SPI_WRITE_16BIT(color);
+  }
 }
 
 void ili9341_bulk(int x, int y, int w, int h)
 {
-//	uint8_t xx[4] = { x >> 8, x, (x+w-1) >> 8, (x+w-1) };
-//	uint8_t yy[4] = { y >> 8, y, (y+h-1) >> 8, (y+h-1) };
-	uint16_t *buf = spi_buffer;
-	uint32_t xx = __REV16(x|((x+w-1)<<16));
-	uint32_t yy = __REV16(y|((y+h-1)<<16));
-	send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
-	send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
-	send_command(ILI9341_MEMORY_WRITE, 0, NULL);
-	int32_t len = w * h;
-	while (len-- > 0){
-		while (SPI_TX_IS_NOT_EMPTY);
-		SPI_WRITE_16BIT(*buf++);
-	}
+//uint8_t xx[4] = { x >> 8, x, (x+w-1) >> 8, (x+w-1) };
+//uint8_t yy[4] = { y >> 8, y, (y+h-1) >> 8, (y+h-1) };
+  uint16_t *buf = spi_buffer;
+  uint32_t xx = __REV16(x|((x+w-1)<<16));
+  uint32_t yy = __REV16(y|((y+h-1)<<16));
+  send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
+  send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
+  send_command(ILI9341_MEMORY_WRITE, 0, NULL);
+  int32_t len = w * h;
+  while (len-- > 0){
+    while (SPI_TX_IS_NOT_EMPTY);
+    SPI_WRITE_16BIT(*buf++);
+  }
 }
 
 static uint8_t ssp_sendrecvdata(void)
 {
-	// Start RX clock (by sending data)
-	SPI_WRITE_8BIT(0);
-	while(SPI_RX_IS_EMPTY && SPI_IS_BUSY)
-		;
-	return SPI_READ_DATA;
+  // Start RX clock (by sending data)
+  SPI_WRITE_8BIT(0);
+  while(SPI_RX_IS_EMPTY && SPI_IS_BUSY)
+    ;
+  return SPI_READ_DATA;
 }
 
 void ili9341_read_memory(int x, int y, int w, int h, int len, uint16_t *out)
 {
-//	uint8_t xx[4] = { x >> 8, x, (x+w-1) >> 8, (x+w-1) };
-//	uint8_t yy[4] = { y >> 8, y, (y+h-1) >> 8, (y+h-1) };
-	uint32_t xx = __REV16(x|((x+w-1)<<16));
-	uint32_t yy = __REV16(y|((y+h-1)<<16));
-	send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
-	send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
-	send_command(ILI9341_MEMORY_READ, 0, NULL);
+//uint8_t xx[4] = { x >> 8, x, (x+w-1) >> 8, (x+w-1) };
+//uint8_t yy[4] = { y >> 8, y, (y+h-1) >> 8, (y+h-1) };
+  uint32_t xx = __REV16(x|((x+w-1)<<16));
+  uint32_t yy = __REV16(y|((y+h-1)<<16));
+  send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
+  send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
+  send_command(ILI9341_MEMORY_READ, 0, NULL);
 
-	// Skip data from rx buffer
-	while (SPI_RX_IS_NOT_EMPTY)
-		(void) SPI_READ_DATA;
-	// require 8bit dummy clock
-	ssp_sendrecvdata();
-	while (len-- > 0) {
-		// read data is always 18bit
-		uint8_t r = ssp_sendrecvdata();
-		uint8_t g = ssp_sendrecvdata();
-		uint8_t b = ssp_sendrecvdata();
-		*out++ = RGB565(r,g,b);
-	}
-	CS_HIGH;
+  // Skip data from rx buffer
+  while (SPI_RX_IS_NOT_EMPTY)
+    (void) SPI_READ_DATA;
+  // require 8bit dummy clock
+  ssp_sendrecvdata();
+  while (len-- > 0) {
+  // read data is always 18bit
+  uint8_t r = ssp_sendrecvdata();
+  uint8_t g = ssp_sendrecvdata();
+  uint8_t b = ssp_sendrecvdata();
+  *out++ = RGB565(r,g,b);
+  }
+  CS_HIGH;
 }
 #else
 //
@@ -415,162 +415,179 @@ void ili9341_read_memory(int x, int y, int w, int h, int len, uint16_t *out)
 // Fill region by some color
 void ili9341_fill(int x, int y, int w, int h, int color)
 {
-	uint32_t xx = __REV16(x|((x+w-1)<<16));
-	uint32_t yy = __REV16(y|((y+h-1)<<16));
-	send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
-	send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
-	send_command(ILI9341_MEMORY_WRITE, 0, NULL);
+  uint32_t xx = __REV16(x|((x+w-1)<<16));
+  uint32_t yy = __REV16(y|((y+h-1)<<16));
+  send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
+  send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
+  send_command(ILI9341_MEMORY_WRITE, 0, NULL);
 
-	dmaStreamSetMemory0(dmatx, &color);
-	dmaStreamSetMode(dmatx, txdmamode | STM32_DMA_CR_PSIZE_HWORD | STM32_DMA_CR_MSIZE_HWORD);
-	dmaStreamFlush(w * h);
+  dmaStreamSetMemory0(dmatx, &color);
+  dmaStreamSetMode(dmatx, txdmamode | STM32_DMA_CR_PSIZE_HWORD | STM32_DMA_CR_MSIZE_HWORD);
+  dmaStreamFlush(w * h);
 }
+
+void ili9341_bulk_8bit(int x, int y, int w, int h, uint16_t *palette){
+  uint32_t xx = __REV16(x|((x+w-1)<<16));
+  uint32_t yy = __REV16(y|((y+h-1)<<16));
+  send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
+  send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
+  send_command(ILI9341_MEMORY_WRITE, 0, NULL);
+
+  uint8_t *buf = (uint8_t *)spi_buffer;
+  int32_t len = w * h;
+  while (len-- > 0){
+    uint16_t color = palette[*buf++];
+    while (SPI_TX_IS_NOT_EMPTY);
+    SPI_WRITE_16BIT(color);
+  }
+}
+
 // Copy spi_buffer to region
 void ili9341_bulk(int x, int y, int w, int h)
 {
-	uint32_t xx = __REV16(x|((x+w-1)<<16));
-	uint32_t yy = __REV16(y|((y+h-1)<<16));
-	send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
-	send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
-	send_command(ILI9341_MEMORY_WRITE, 0, NULL);
+  uint32_t xx = __REV16(x|((x+w-1)<<16));
+  uint32_t yy = __REV16(y|((y+h-1)<<16));
+  send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
+  send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
+  send_command(ILI9341_MEMORY_WRITE, 0, NULL);
 
-	// Init Tx DMA mem->spi, set size, mode (spi and mem data size is 16 bit)
-    dmaStreamSetMemory0(dmatx, spi_buffer);
-    dmaStreamSetMode(dmatx, txdmamode | STM32_DMA_CR_PSIZE_HWORD | STM32_DMA_CR_MSIZE_HWORD | STM32_DMA_CR_MINC);
-    dmaStreamFlush(w * h);
+  // Init Tx DMA mem->spi, set size, mode (spi and mem data size is 16 bit)
+  dmaStreamSetMemory0(dmatx, spi_buffer);
+  dmaStreamSetMode(dmatx, txdmamode | STM32_DMA_CR_PSIZE_HWORD | STM32_DMA_CR_MSIZE_HWORD | STM32_DMA_CR_MINC);
+  dmaStreamFlush(w * h);
 }
 
 // Copy screen data to buffer
 // Warning!!! buffer size must be greater then 3*len + 1 bytes
 void ili9341_read_memory(int x, int y, int w, int h, int len, uint16_t *out)
 {
-	uint8_t dummy_tx = 0;
-	uint8_t *rgbbuf=(uint8_t *)out;
-	uint16_t data_size = len * 3 + 1;
-	uint32_t xx = __REV16(x|((x+w-1)<<16));
-	uint32_t yy = __REV16(y|((y+h-1)<<16));
-	send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
-	send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
-	send_command(ILI9341_MEMORY_READ, 0, NULL);
-	// Skip SPI rx buffer
-	while (SPI_RX_IS_NOT_EMPTY)
-		(void) SPI_READ_DATA;
-	// Init Rx DMA buffer, size, mode (spi and mem data size is 8 bit)
-	dmaStreamSetMemory0(dmarx, rgbbuf);
-	dmaStreamSetTransactionSize(dmarx, data_size);
-	dmaStreamSetMode(dmarx, rxdmamode | STM32_DMA_CR_PSIZE_BYTE | STM32_DMA_CR_MSIZE_BYTE | STM32_DMA_CR_MINC);
-	// Init dummy Tx DMA (for rx clock), size, mode (spi and mem data size is 8 bit)
-	dmaStreamSetMemory0(dmatx, &dummy_tx);
-	dmaStreamSetTransactionSize(dmatx, data_size);
-	dmaStreamSetMode(dmatx, txdmamode | STM32_DMA_CR_PSIZE_BYTE | STM32_DMA_CR_MSIZE_BYTE);
-	
-	// Start DMA exchange
-	dmaStreamEnable(dmatx);
-	dmaStreamEnable(dmarx);
-	// Wait DMA completion
-	dmaWaitCompletion(dmatx);
-	dmaWaitCompletion(dmarx);
-	CS_HIGH;
+  uint8_t dummy_tx = 0;
+  uint8_t *rgbbuf=(uint8_t *)out;
+  uint16_t data_size = len * 3 + 1;
+  uint32_t xx = __REV16(x|((x+w-1)<<16));
+  uint32_t yy = __REV16(y|((y+h-1)<<16));
+  send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
+  send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
+  send_command(ILI9341_MEMORY_READ, 0, NULL);
+  // Skip SPI rx buffer
+  while (SPI_RX_IS_NOT_EMPTY)
+    (void) SPI_READ_DATA;
+  // Init Rx DMA buffer, size, mode (spi and mem data size is 8 bit)
+  dmaStreamSetMemory0(dmarx, rgbbuf);
+  dmaStreamSetTransactionSize(dmarx, data_size);
+  dmaStreamSetMode(dmarx, rxdmamode | STM32_DMA_CR_PSIZE_BYTE | STM32_DMA_CR_MSIZE_BYTE | STM32_DMA_CR_MINC);
+  // Init dummy Tx DMA (for rx clock), size, mode (spi and mem data size is 8 bit)
+  dmaStreamSetMemory0(dmatx, &dummy_tx);
+  dmaStreamSetTransactionSize(dmatx, data_size);
+  dmaStreamSetMode(dmatx, txdmamode | STM32_DMA_CR_PSIZE_BYTE | STM32_DMA_CR_MSIZE_BYTE);
+  
+  // Start DMA exchange
+  dmaStreamEnable(dmatx);
+  dmaStreamEnable(dmarx);
+  // Wait DMA completion
+  dmaWaitCompletion(dmatx);
+  dmaWaitCompletion(dmarx);
+  CS_HIGH;
 
-	// Parce recived data
-	// Skip dummy 8-bit read
-	rgbbuf++;
-	while (len-- > 0) {
-		uint8_t r, g, b;
-		// read data is always 18bit
-		r = rgbbuf[0];
-		g = rgbbuf[1];
-		b = rgbbuf[2];
-		*out++ = RGB565(r,g,b);
-		rgbbuf+=3;
-	}
+  // Parce recived data
+  // Skip dummy 8-bit read
+  rgbbuf++;
+  while (len-- > 0) {
+    uint8_t r, g, b;
+    // read data is always 18bit
+    r = rgbbuf[0];
+    g = rgbbuf[1];
+    b = rgbbuf[2];
+    *out++ = RGB565(r,g,b);
+    rgbbuf+=3;
+  }
 }
 #endif
 
 void clearScreen(void){
-	ili9341_fill(0, 0, ILI9341_WIDTH, ILI9341_HEIGHT, background_color);
+  ili9341_fill(0, 0, ILI9341_WIDTH, ILI9341_HEIGHT, background_color);
 }
 
 void setForegroundColor(uint16_t fg) {foreground_color = fg;}
 void setBackgroundColor(uint16_t bg) {background_color = bg;}
 
 void ili9341_setRotation(uint8_t r) {
-//	static const uint8_t rotation_const[]={DISPLAY_ROTATION_0, DISPLAY_ROTATION_90, DISPLAY_ROTATION_180, DISPLAY_ROTATION_270};
-	send_command(ILI9341_MEMORY_ACCESS_CONTROL, 1, &r);
+//  static const uint8_t rotation_const[]={DISPLAY_ROTATION_0, DISPLAY_ROTATION_90, DISPLAY_ROTATION_180, DISPLAY_ROTATION_270};
+  send_command(ILI9341_MEMORY_ACCESS_CONTROL, 1, &r);
 }
 
 void blit8BitWidthBitmap(uint16_t x, uint16_t y, uint16_t width, uint16_t height, const uint8_t *bitmap){
-    uint16_t *buf = spi_buffer;
-    for(uint16_t c = 0; c < height; c++) {
-    	uint8_t bits = *bitmap++;
-        for (uint16_t r = 0; r < width; r++) {
-            *buf++ = (0x80 & bits) ? foreground_color : background_color;
-            bits <<= 1;
-        }
-    }
-    ili9341_bulk(x, y, width, height);
+  uint16_t *buf = spi_buffer;
+  for(uint16_t c = 0; c < height; c++) {
+    uint8_t bits = *bitmap++;
+      for (uint16_t r = 0; r < width; r++) {
+        *buf++ = (0x80 & bits) ? foreground_color : background_color;
+        bits <<= 1;
+      }
+  }
+  ili9341_bulk(x, y, width, height);
 }
 
 void blit16BitWidthBitmap(uint16_t x, uint16_t y, uint16_t width, uint16_t height, const uint16_t *bitmap){
-    uint16_t *buf = spi_buffer;
-    for(uint16_t c = 0; c < height; c++) {
-    	uint16_t bits = *bitmap++;
-        for (uint16_t r = 0; r < width; r++) {
-            *buf++ = (0x8000 & bits) ? foreground_color : background_color;
-            bits <<= 1;
-        }
+  uint16_t *buf = spi_buffer;
+  for(uint16_t c = 0; c < height; c++) {
+    uint16_t bits = *bitmap++;
+    for (uint16_t r = 0; r < width; r++) {
+      *buf++ = (0x8000 & bits) ? foreground_color : background_color;
+      bits <<= 1;
     }
-    ili9341_bulk(x, y, width, height);
+  }
+  ili9341_bulk(x, y, width, height);
 }
 
 void ili9341_drawchar(uint8_t ch, int x, int y)
 {
-	blit8BitWidthBitmap(x, y, FONT_GET_WIDTH(ch), FONT_GET_HEIGHT, FONT_GET_DATA(ch));
+  blit8BitWidthBitmap(x, y, FONT_GET_WIDTH(ch), FONT_GET_HEIGHT, FONT_GET_DATA(ch));
 }
 
 void ili9341_drawstring(const char *str, int x, int y)
 {
-    while (*str) {
-    	uint8_t ch = *str++;
-        const uint8_t *char_buf = FONT_GET_DATA(ch);
-        uint16_t w = FONT_GET_WIDTH(ch);
-        blit8BitWidthBitmap(x, y, w, FONT_GET_HEIGHT, char_buf);
-        x+=w;
-    }
+  while (*str) {
+    uint8_t ch = *str++;
+    const uint8_t *char_buf = FONT_GET_DATA(ch);
+    uint16_t w = FONT_GET_WIDTH(ch);
+    blit8BitWidthBitmap(x, y, w, FONT_GET_HEIGHT, char_buf);
+    x+=w;
+  }
 }
 
 void ili9341_drawstringV(const char *str, int x, int y){
-	ili9341_setRotation(DISPLAY_ROTATION_270);
-	ili9341_drawstring(str, ILI9341_HEIGHT-y, x);
-	ili9341_setRotation(DISPLAY_ROTATION_0);
+  ili9341_setRotation(DISPLAY_ROTATION_270);
+  ili9341_drawstring(str, ILI9341_HEIGHT-y, x);
+  ili9341_setRotation(DISPLAY_ROTATION_0);
 }
 
 int ili9341_drawchar_size(uint8_t ch, int x, int y, uint8_t size)
 {
-    uint16_t *buf = spi_buffer;
-    const uint8_t *char_buf = FONT_GET_DATA(ch);
-    uint16_t w=FONT_GET_WIDTH(ch);
-    for(int c = 0; c < FONT_GET_HEIGHT; c++, char_buf++){
-    	for (int i=0;i<size;i++){
-    	uint8_t bits = *char_buf;
-        for (int r = 0; r < w; r++, bits<<=1)
-        	for (int j=0; j<size; j++)
-        		*buf++ = (0x80 & bits) ? foreground_color : background_color;
-    	}
+  uint16_t *buf = spi_buffer;
+  const uint8_t *char_buf = FONT_GET_DATA(ch);
+  uint16_t w=FONT_GET_WIDTH(ch);
+  for(int c = 0; c < FONT_GET_HEIGHT; c++, char_buf++){
+    for (int i=0;i<size;i++){
+    uint8_t bits = *char_buf;
+    for (int r = 0; r < w; r++, bits<<=1)
+      for (int j=0; j<size; j++)
+        *buf++ = (0x80 & bits) ? foreground_color : background_color;
     }
-    ili9341_bulk(x, y, w*size, FONT_GET_HEIGHT*size);
-    return w*size;
+  }
+  ili9341_bulk(x, y, w*size, FONT_GET_HEIGHT*size);
+  return w*size;
 }
 
 void ili9341_drawfont(uint8_t ch, int x, int y)
 {
-	blit16BitWidthBitmap(x, y, NUM_FONT_GET_WIDTH, NUM_FONT_GET_HEIGHT, NUM_FONT_GET_DATA(ch));
+  blit16BitWidthBitmap(x, y, NUM_FONT_GET_WIDTH, NUM_FONT_GET_HEIGHT, NUM_FONT_GET_DATA(ch));
 }
 
 void ili9341_drawstring_size(const char *str, int x, int y, uint8_t size)
 {
-    while (*str)
-        x += ili9341_drawchar_size(*str++, x, y, size);
+  while (*str)
+    x += ili9341_drawchar_size(*str++, x, y, size);
 }
 #if 0
 static void ili9341_pixel(int x, int y, uint16_t color)
@@ -601,86 +618,86 @@ void ili9341_line(int x0, int y0, int x1, int y1)
   }
 #endif
 
-    if (x0 > x1) {
-        SWAP(x0, x1);
-        SWAP(y0, y1);
-    }
+  if (x0 > x1) {
+    SWAP(x0, x1);
+    SWAP(y0, y1);
+  }
 
-    while (x0 <= x1) {
-        int dx = x1 - x0 + 1;
-        int dy = y1 - y0;
-        if (dy >= 0) {
-            dy++;
-            if (dy > dx) {
-                dy /= dx; dx = 1;
-            } else {
-                dx /= dy; dy = 1;
-            }
-        } else {
-            dy--;
-            if (-dy > dx) {
-                dy /= dx; dx = 1;
-            } else {
-                dx /= -dy;dy = -1;
-            }
-        }
-        if (dy > 0)
-            ili9341_fill(x0, y0, dx, dy, foreground_color);
-        else
-            ili9341_fill(x0, y0+dy, dx, -dy, foreground_color);
-        x0 += dx;
-        y0 += dy;
+  while (x0 <= x1) {
+    int dx = x1 - x0 + 1;
+    int dy = y1 - y0;
+    if (dy >= 0) {
+      dy++;
+      if (dy > dx) {
+        dy /= dx; dx = 1;
+      } else {
+        dx /= dy; dy = 1;
+      }
+    } else {
+      dy--;
+      if (-dy > dx) {
+        dy /= dx; dx = 1;
+      } else {
+        dx /= -dy;dy = -1;
+      }
     }
+    if (dy > 0)
+      ili9341_fill(x0, y0, dx, dy, foreground_color);
+    else
+      ili9341_fill(x0, y0+dy, dx, -dy, foreground_color);
+    x0 += dx;
+    y0 += dy;
+  }
 }
 
 #if 0
 static const uint16_t colormap[] = {
-    RGBHEX(0x00ff00), RGBHEX(0x0000ff), RGBHEX(0xff0000),
-    RGBHEX(0x00ffff), RGBHEX(0xff00ff), RGBHEX(0xffff00)
+  RGBHEX(0x00ff00), RGBHEX(0x0000ff), RGBHEX(0xff0000),
+  RGBHEX(0x00ffff), RGBHEX(0xff00ff), RGBHEX(0xffff00)
 };
 
 void ili9341_test(int mode)
 {
-    int x, y;
-    int i;
-    switch (mode) {
-        default:
+  int x, y;
+  int i;
+  switch (mode) {
+    default:
 #if 1
-            ili9341_fill(0, 0, 320, 240, 0);
-            for (y = 0; y < 240; y++) {
-                ili9341_fill(0, y, 320, 1, RGB(240-y, y, (y + 120) % 256));
-            }
-            break;
-        case 1:
-            ili9341_fill(0, 0, 320, 240, 0);
-            for (y = 0; y < 240; y++) {
-                for (x = 0; x < 320; x++) {
-                    ili9341_pixel(x, y, (y<<8)|x);
-                }
-            }
-            break;
-        case 2:
-            //send_command16(0x55, 0xff00);
-            ili9341_pixel(64, 64, 0xaa55);
-            break;
+    ili9341_fill(0, 0, 320, 240, 0);
+    for (y = 0; y < 240; y++) {
+      ili9341_fill(0, y, 320, 1, RGB(240-y, y, (y + 120) % 256));
+    }
+    break;
+    case 1:
+      ili9341_fill(0, 0, 320, 240, 0);
+      for (y = 0; y < 240; y++) {
+        for (x = 0; x < 320; x++) {
+          ili9341_pixel(x, y, (y<<8)|x);
+        }
+      }
+      break;
+    case 2:
+      //send_command16(0x55, 0xff00);
+      ili9341_pixel(64, 64, 0xaa55);
+    break;
 #endif
 #if 1
-        case 3:
-            for (i = 0; i < 10; i++)
-                ili9341_drawfont(i, i*20, 120);
-            break;
+    case 3:
+      for (i = 0; i < 10; i++)
+        ili9341_drawfont(i, i*20, 120);
+    break;
 #endif
 #if 0
-        case 4:
-            draw_grid(10, 8, 29, 29, 15, 0, 0xffff, 0);
-            break;
+    case 4:
+      draw_grid(10, 8, 29, 29, 15, 0, 0xffff, 0);
+    break;
 #endif
-        case 4:
-            ili9341_line(0, 0, 15, 100);
-            ili9341_line(0, 0, 100, 100);
-            ili9341_line(0, 15, 100, 0);
-            ili9341_line(0, 100, 100, 0);
-            break;
-    }
+    case 4:
+      ili9341_line(0, 0, 15, 100);
+      ili9341_line(0, 0, 100, 100);
+      ili9341_line(0, 15, 100, 0);
+      ili9341_line(0, 100, 100, 0);
+    break;
+  }
 }
 #endif

--- a/main.c
+++ b/main.c
@@ -856,7 +856,7 @@ VNA_SHELL_FUNCTION(cmd_scan)
   }
   if (argc >= 3) {
     points = my_atoi(argv[2]);
-    if (points <= 0 || points > sweep_points) {
+    if (points <= 0 || points > POINTS_COUNT) {
       shell_printf("sweep points exceeds range "define_to_STR(POINTS_COUNT)"\r\n");
       return;
     }
@@ -929,7 +929,7 @@ set_frequencies(uint32_t start, uint32_t stop, uint16_t points)
     }
   }
   // disable at out of sweep range
-  for (; i < sweep_points; i++)
+  for (; i < POINTS_COUNT; i++)
     frequencies[i] = 0;
 }
 
@@ -1360,7 +1360,7 @@ cal_interpolate(int s)
   for (; i < sweep_points; i++) {
     uint32_t f = frequencies[i];
 
-    for (; j < sweep_points-1; j++) {
+    for (; j < src->_sweep_points-1; j++) {
       if (src->_frequencies[j] <= f && f < src->_frequencies[j+1]) {
         // found f between freqs at j and j+1
         float k1 = (float)(f - src->_frequencies[j])
@@ -1380,7 +1380,7 @@ cal_interpolate(int s)
         break;
       }
     }
-    if (j == sweep_points-1)
+    if (j == src->_sweep_points-1)
       break;
   }
   

--- a/main.c
+++ b/main.c
@@ -518,7 +518,7 @@ VNA_SHELL_FUNCTION(cmd_dac)
                  "current value: %d\r\n", config.dac_value);
     return;
   }
-  value = my_atoi(argv[0]);
+  value = my_atoui(argv[0]);
   config.dac_value = value;
   dacPutChannelX(&DACD2, 0, value);
 }
@@ -2177,8 +2177,9 @@ static void VNAShell_executeLine(char *line){
       if (scp->flags&CMD_WAIT_MUTEX){
         shell_function= scp->sc_function;
         // Wait execute command in sweep thread
-        while(shell_function)
-          osalThreadSleepMilliseconds(100);
+        do{
+          osalThreadSleepMilliseconds(100);}
+        while(shell_function);
       }
       else
         scp->sc_function(shell_nargs-1, &shell_args[1]);

--- a/main.c
+++ b/main.c
@@ -841,9 +841,9 @@ VNA_SHELL_FUNCTION(cmd_scan)
 {
   uint32_t start, stop;
   int16_t points = sweep_points;
-
-  if (argc != 2 && argc != 3) {
-    shell_printf("usage: scan {start(Hz)} {stop(Hz)} [points]\r\n");
+  int i;
+  if (argc < 2 || argc > 4) {
+    shell_printf("usage: scan {start(Hz)} {stop(Hz)} [points] [outmask]\r\n");
     return;
   }
 
@@ -866,6 +866,20 @@ VNA_SHELL_FUNCTION(cmd_scan)
     cal_interpolate(lastsaveid);
   pause_sweep();
   sweep(false);
+  // Output data after if set (faster data recive)
+  if (argc == 4){
+    uint16_t mask = my_atoui(argv[3]);
+    if (mask)
+    for (i = 0; i < points; i++){
+      if (mask&1)
+        shell_printf("%u ", frequencies[i]);
+      if (mask&2)
+        shell_printf("%f %f ", measured[0][i][0], measured[0][i][1]);
+      if (mask&4)
+        shell_printf("%f %f ", measured[1][i][0], measured[1][i][1]);
+      shell_printf("\r\n");
+    }
+  }
 }
 
 static void
@@ -1719,7 +1733,7 @@ VNA_SHELL_FUNCTION(cmd_frequencies)
   (void)argv;
   for (i = 0; i < sweep_points; i++) {
     if (frequencies[i] != 0)
-      shell_printf("%d\r\n", frequencies[i]);
+      shell_printf("%u\r\n", frequencies[i]);
   }
 }
 

--- a/main.c
+++ b/main.c
@@ -803,6 +803,7 @@ bool sweep(bool break_on_operation)
   palClearPad(GPIOC, GPIOC_LED);
   // Power stabilization after LED off, also align timings on i == 0
   for (i = 0; i < sweep_points; i++) {         // 5300
+    if (frequencies[i] == 0) break;
     delay = set_frequency(frequencies[i]);     // 700
     tlv320aic3204_select(0);                   // 60 CH0:REFLECT, reset and begin measure
     DSP_START(delay+((i==0)?2:0));             // 1900
@@ -853,10 +854,10 @@ VNA_SHELL_FUNCTION(cmd_scan)
       shell_printf("frequency range is invalid\r\n");
       return;
   }
-  if (argc == 3) {
+  if (argc >= 3) {
     points = my_atoi(argv[2]);
     if (points <= 0 || points > sweep_points) {
-      shell_printf("sweep points exceeds range\r\n");
+      shell_printf("sweep points exceeds range "define_to_STR(POINTS_COUNT)"\r\n");
       return;
     }
   }
@@ -2148,9 +2149,6 @@ static int VNAShell_readLine(char *line, int max_size){
   return 0;
 }
 
-// Macros for convert define value to string
-#define STR1(x)  #x
-#define define_to_STR(x)  STR1(x)
 //
 // Parse and run command line
 //

--- a/main.c
+++ b/main.c
@@ -804,18 +804,11 @@ bool sweep(bool break_on_operation)
   // blink LED while scanning
   palClearPad(GPIOC, GPIOC_LED);
   // Power stabilization after LED off, also align timings on i == 0
-
-  // !!!!! Don`t understand why si5351 non stable on band 2 then change from band 3
-  // It fixed if set before one band 1 frequency
-  // Possibly problem in gain, call only si5351_set_frequency_with_offset not work
-  // Also it allow align sweep timings
-  set_frequency(50000000);
-  DSP_START(1);DSP_WAIT_READY;
   for (i = 0; i < sweep_points; i++) {         // 5300
     if (frequencies[i] == 0) break;
     delay = set_frequency(frequencies[i]);     // 700
     tlv320aic3204_select(0);                   // 60 CH0:REFLECT, reset and begin measure
-    DSP_START(delay);                          // 1900
+    DSP_START(delay+((i==0)?1:0));             // 1900
     //================================================
     // Place some code thats need execute while delay
     //================================================

--- a/nanovna.h
+++ b/nanovna.h
@@ -284,6 +284,7 @@ int marker_search_right(int from);
 #define REDRAW_CAL_STATUS (1<<2)
 #define REDRAW_MARKER     (1<<3)
 #define REDRAW_BATTERY    (1<<4)
+#define REDRAW_AREA       (1<<5)
 extern volatile uint8_t redraw_request;
 
 /*

--- a/nanovna.h
+++ b/nanovna.h
@@ -25,9 +25,17 @@
 /*
  * main.c
  */
-#define START_MIN 50000
-#define STOP_MAX 2700000000U
-#define SPEED_OF_LIGHT 299792458
+
+// Minimum frequency set
+#define START_MIN                50000
+// Maximum frequency set
+#define STOP_MAX                 2700000000U
+// Frequency offset (sin_cos table in dsp.c generated for this offset, if change need create new table)
+#define FREQUENCY_OFFSET         5000
+// Speed of light const
+#define SPEED_OF_LIGHT           299792458
+// pi const
+#define VNA_PI                   3.14159265358979323846
 
 #define POINTS_COUNT 101
 extern float measured[2][POINTS_COUNT][2];

--- a/nanovna.h
+++ b/nanovna.h
@@ -490,4 +490,7 @@ int plot_printf(char *str, int, const char *fmt, ...);
 // Speed profile definition
 #define START_PROFILE   systime_t time = chVTGetSystemTimeX();
 #define STOP_PROFILE    {char string_buf[12];plot_printf(string_buf, sizeof string_buf, "T:%06d", chVTGetSystemTimeX() - time);ili9341_drawstringV(string_buf, 1, 60);}
+// Macros for convert define value to string
+#define STR1(x)  #x
+#define define_to_STR(x)  STR1(x)
 /*EOF*/

--- a/nanovna.h
+++ b/nanovna.h
@@ -209,6 +209,9 @@ typedef struct trace {
   float refpos;
 } trace_t;
 
+#define FREQ_MODE_START_STOP    0x0
+#define FREQ_MODE_CENTER_SPAN   0x1
+
 typedef struct config {
   int32_t magic;
   uint16_t dac_value;
@@ -217,7 +220,7 @@ typedef struct config {
   uint16_t menu_active_color;
   uint16_t trace_color[TRACES_MAX];
   int16_t  touch_cal[4];
-  int8_t   reserved_1;
+  int8_t   freq_mode;
   uint32_t harmonic_freq_threshold;
   uint16_t vbat_offset;
   uint8_t _reserved[22];
@@ -225,8 +228,6 @@ typedef struct config {
 } config_t;
 
 extern config_t config;
-
-//extern trace_t trace[TRACES_MAX];
 
 void set_trace_type(int t, int type);
 void set_trace_channel(int t, int channel);
@@ -396,13 +397,9 @@ extern properties_t current_props;
 #define velocity_factor current_props._velocity_factor
 #define marker_smith_format current_props._marker_smith_format
 
-#define FREQ_IS_STARTSTOP() (frequency0 < frequency1)
-#define FREQ_IS_CENTERSPAN() (frequency0 > frequency1)
+#define FREQ_IS_STARTSTOP() (!(config.freq_mode&FREQ_MODE_CENTER_SPAN))
+#define FREQ_IS_CENTERSPAN() (config.freq_mode&FREQ_MODE_CENTER_SPAN)
 #define FREQ_IS_CW() (frequency0 == frequency1)
-#define FREQ_START() (frequency0)
-#define FREQ_STOP() (frequency1)
-#define FREQ_CENTER() (frequency0/2 + frequency1/2)
-#define FREQ_SPAN() (frequency0 - frequency1)
 
 int caldata_save(int id);
 int caldata_recall(int id);

--- a/nanovna.h
+++ b/nanovna.h
@@ -261,7 +261,7 @@ void redraw_frame(void);
 //void redraw_all(void);
 void request_to_draw_cells_behind_menu(void);
 void request_to_draw_cells_behind_numeric_input(void);
-void redraw_marker(int marker, int update_info);
+void redraw_marker(int marker);
 void plot_into_index(float measured[2][POINTS_COUNT][2]);
 void force_set_markmap(void);
 void draw_frequencies(void);

--- a/nanovna.h
+++ b/nanovna.h
@@ -27,6 +27,7 @@
  */
 #define START_MIN 50000
 #define STOP_MAX 2700000000U
+#define SPEED_OF_LIGHT 299792458
 
 #define POINTS_COUNT 101
 extern float measured[2][POINTS_COUNT][2];
@@ -211,6 +212,7 @@ typedef struct trace {
 
 #define FREQ_MODE_START_STOP    0x0
 #define FREQ_MODE_CENTER_SPAN   0x1
+#define FREQ_MODE_DOTTED_GRID   0x2
 
 typedef struct config {
   int32_t magic;

--- a/plot.c
+++ b/plot.c
@@ -1585,18 +1585,18 @@ draw_frequencies(void)
   char buf1[32];
   char buf2[32];buf2[0]=0;
   if ((domain_mode & DOMAIN_MODE) == DOMAIN_FREQ) {
-      if (FREQ_IS_STARTSTOP()) {
-        plot_printf(buf1, sizeof(buf1), " START %qHz", frequency0);
-        plot_printf(buf2, sizeof(buf2), " STOP %qHz", frequency1);
-      } else if (FREQ_IS_CENTERSPAN()) {
-        plot_printf(buf1, sizeof(buf1), " CENTER %qHz", FREQ_CENTER());
-        plot_printf(buf2, sizeof(buf2), " SPAN %qHz", FREQ_SPAN());
-      } else {
-        plot_printf(buf1, sizeof(buf1), " CW %qHz", frequency0);
-      }
+    if (FREQ_IS_CW()){
+      plot_printf(buf1, sizeof(buf1), " CW %qHz", get_sweep_frequency(ST_CW));
+    } else if (FREQ_IS_STARTSTOP()) {
+      plot_printf(buf1, sizeof(buf1), " START %qHz", get_sweep_frequency(ST_START));
+      plot_printf(buf2, sizeof(buf2), " STOP %qHz", get_sweep_frequency(ST_STOP));
+    } else if (FREQ_IS_CENTERSPAN()) {
+      plot_printf(buf1, sizeof(buf1), " CENTER %qHz", get_sweep_frequency(ST_CENTER));
+      plot_printf(buf2, sizeof(buf2), " SPAN %qHz", get_sweep_frequency(ST_SPAN));
+    }
   } else {
-      plot_printf(buf1, sizeof(buf1), " START 0s");
-      plot_printf(buf2, sizeof(buf2), "STOP %Fs (%Fm)", time_of_index(POINTS_COUNT-1), distance_of_index(POINTS_COUNT-1));
+    plot_printf(buf1, sizeof(buf1), " START 0s");
+    plot_printf(buf2, sizeof(buf2), "STOP %Fs (%Fm)", time_of_index(POINTS_COUNT-1), distance_of_index(POINTS_COUNT-1));
   }
   setForegroundColor(DEFAULT_FG_COLOR);
   setBackgroundColor(DEFAULT_BG_COLOR);

--- a/plot.c
+++ b/plot.c
@@ -1387,7 +1387,7 @@ draw_all(bool flush)
 }
 
 void
-redraw_marker(int marker, int update_info)
+redraw_marker(int marker)
 {
   if (marker < 0)
     return;
@@ -1395,8 +1395,7 @@ redraw_marker(int marker, int update_info)
   markmap_marker(marker);
 
   // mark cells on marker info
-  if (update_info)
-    markmap_upperarea();
+  markmap_upperarea();
 
   draw_all_cells(TRUE);
 }

--- a/plot.c
+++ b/plot.c
@@ -1636,27 +1636,17 @@ draw_cal_status(void)
     ili9341_drawstring(c, x, y);
     y += YSTEP;
   }
-
-  if (cal_status & CALSTAT_ED) {
-    ili9341_drawstring("D", x, y);
-    y += YSTEP;
-  }
-  if (cal_status & CALSTAT_ER) {
-    ili9341_drawstring("R", x, y);
-    y += YSTEP;
-  }
-  if (cal_status & CALSTAT_ES) {
-    ili9341_drawstring("S", x, y);
-    y += YSTEP;
-  }
-  if (cal_status & CALSTAT_ET) {
-    ili9341_drawstring("T", x, y);
-    y += YSTEP;
-  }
-  if (cal_status & CALSTAT_EX) {
-    ili9341_drawstring("X", x, y);
-    y += YSTEP;
-  }
+  int i;
+  static const struct {char text, zero, mask;} calibration_text[]={
+    {'D', 0, CALSTAT_ED},
+    {'R', 0, CALSTAT_ER},
+    {'S', 0, CALSTAT_ES},
+    {'T', 0, CALSTAT_ET},
+    {'X', 0, CALSTAT_EX}
+  };
+  for (i = 0; i < 5; i++, y+= YSTEP)
+    if (cal_status & calibration_text[i].mask)
+      ili9341_drawstring(&calibration_text[i].text, x, y);
 }
 
 // Draw battery level

--- a/plot.c
+++ b/plot.c
@@ -787,48 +787,29 @@ invalidateRect(int x0, int y0, int x1, int y1){
       mark_map(x, y);
 }
 
+#define SWAP(x,y) {int t=x;x=y;y=t;}
+
 static void
 mark_cells_from_index(void)
 {
-  int t;
+  int t, i;
   /* mark cells between each neighber points */
   for (t = 0; t < TRACES_MAX; t++) {
     if (!trace[t].enabled)
       continue;
-    int x0 = CELL_X(trace_index[t][0]);
-    int y0 = CELL_Y(trace_index[t][0]);
-    int m0 = x0 / CELLWIDTH;
-    int n0 = y0 / CELLHEIGHT;
-    int i;
-    mark_map(m0, n0);
+    int m0 = CELL_X(trace_index[t][0]) / CELLWIDTH;
+    int n0 = CELL_Y(trace_index[t][0]) / CELLHEIGHT;
+    markmap[current_mappage][n0] |= 1<<m0;
     for (i = 1; i < sweep_points; i++) {
-      int x1 = CELL_X(trace_index[t][i]);
-      int y1 = CELL_Y(trace_index[t][i]);
-      int m1 = x1 / CELLWIDTH;
-      int n1 = y1 / CELLHEIGHT;
-      while (m0 != m1 || n0 != n1) {
-        if (m0 == m1) {
-          if (n0 < n1) n0++; else n0--;
-        } else if (n0 == n1) {
-          if (m0 < m1) m0++; else m0--;
-        } else {
-          int x = ((m0 < m1) ? (m0 + 1) : m0) * CELLWIDTH;
-          int y = ((n0 < n1) ? (n0 + 1) : n0) * CELLHEIGHT;
-          int sgn = (n0 < n1) ? 1 : -1;
-          if (sgn*(y-y0)*(x1-x0) < sgn*(x-x0)*(y1-y0)) {
-            if (m0 < m1) m0++;
-            else m0--;
-          } else {
-            if (n0 < n1) n0++;
-            else n0--;
-          }
-        }
-        mark_map(m0, n0);
-      }
-      x0 = x1;
-      y0 = y1;
-      m0 = m1;
-      n0 = n1;
+      int m1 = CELL_X(trace_index[t][i]) / CELLWIDTH;
+      int n1 = CELL_Y(trace_index[t][i]) / CELLHEIGHT;
+      if (m0 == m1 && n0 == n1)
+        continue;
+      int x0 = m0; int x1 = m1; if (x0>x1) SWAP(x0, x1); m0=m1;
+      int y0 = n0; int y1 = n1; if (y0>y1) SWAP(y0, y1); n0=n1;
+      for (; y0<=y1; y0++)
+        for(int j=x0;j<=x1;j++)
+          markmap[current_mappage][y0]|= 1<<x0;
     }
   }
 }
@@ -840,7 +821,6 @@ markmap_upperarea(void)
   invalidateRect(0, 0, AREA_WIDTH_NORMAL, 31);
 }
 
-#define SWAP(x,y) {int t=x;x=y;y=t;}
 //
 // in most cases _compute_outcode clip calculation not give render line speedup
 //

--- a/plot.c
+++ b/plot.c
@@ -792,24 +792,26 @@ invalidateRect(int x0, int y0, int x1, int y1){
 static void
 mark_cells_from_index(void)
 {
-  int t, i;
+  int t, i, j;
   /* mark cells between each neighber points */
+  uint16_t *map = &markmap[current_mappage][0];
   for (t = 0; t < TRACES_MAX; t++) {
     if (!trace[t].enabled)
       continue;
-    int m0 = CELL_X(trace_index[t][0]) / CELLWIDTH;
-    int n0 = CELL_Y(trace_index[t][0]) / CELLHEIGHT;
-    markmap[current_mappage][n0] |= 1<<m0;
+    uint32_t *index = &trace_index[t][0];
+    int m0 = CELL_X(index[0]) / CELLWIDTH;
+    int n0 = CELL_Y(index[0]) / CELLHEIGHT;
+    map[n0]|= 1<<m0;
     for (i = 1; i < sweep_points; i++) {
-      int m1 = CELL_X(trace_index[t][i]) / CELLWIDTH;
-      int n1 = CELL_Y(trace_index[t][i]) / CELLHEIGHT;
+      int m1 = CELL_X(index[i]) / CELLWIDTH;
+      int n1 = CELL_Y(index[i]) / CELLHEIGHT;
       if (m0 == m1 && n0 == n1)
         continue;
       int x0 = m0; int x1 = m1; if (x0>x1) SWAP(x0, x1); m0=m1;
       int y0 = n0; int y1 = n1; if (y0>y1) SWAP(y0, y1); n0=n1;
       for (; y0<=y1; y0++)
-        for(int j=x0;j<=x1;j++)
-          markmap[current_mappage][y0]|= 1<<x0;
+        for(j=x0; j<=x1; j++)
+         map[y0]|= 1<<x0;
     }
   }
 }

--- a/plot.c
+++ b/plot.c
@@ -499,7 +499,7 @@ float
 groupdelay_from_array(int i, float array[POINTS_COUNT][2])
 {
   int bottom = (i ==   0) ?   0 : i - 1;
-  int top    = (i == POINTS_COUNT-1) ? POINTS_COUNT-1 : i + 1;
+  int top    = (i == sweep_points-1) ? sweep_points-1 : i + 1;
   float deltaf = frequencies[top] - frequencies[bottom];
   return groupdelay(array[bottom], array[top], deltaf);
 }
@@ -1062,7 +1062,7 @@ marker_search(void)
     return -1;
 
   int value = CELL_Y(trace_index[uistat.current_trace][0]);
-  for (i = 0; i < POINTS_COUNT; i++) {
+  for (i = 0; i < sweep_points; i++) {
     index_t index = trace_index[uistat.current_trace][i];
     if ((*compare)(value, CELL_Y(index))) {
       value = CELL_Y(index);
@@ -1117,14 +1117,14 @@ marker_search_right(int from)
     return -1;
 
   int value = CELL_Y(trace_index[uistat.current_trace][from]);
-  for (i = from + 1; i < POINTS_COUNT; i++) {
+  for (i = from + 1; i < sweep_points; i++) {
     index_t index = trace_index[uistat.current_trace][i];
     if ((*compare)(value, CELL_Y(index)))
       break;
     value = CELL_Y(index);
   }
 
-  for (; i < POINTS_COUNT; i++) {
+  for (; i < sweep_points; i++) {
     index_t index = trace_index[uistat.current_trace][i];
     if ((*compare)(CELL_Y(index), value)) {
       break;
@@ -1603,7 +1603,7 @@ draw_frequencies(void)
     }
   } else {
     plot_printf(buf1, sizeof(buf1), " START 0s");
-    plot_printf(buf2, sizeof(buf2), "STOP %Fs (%Fm)", time_of_index(POINTS_COUNT-1), distance_of_index(POINTS_COUNT-1));
+    plot_printf(buf2, sizeof(buf2), "STOP %Fs (%Fm)", time_of_index(sweep_points-1), distance_of_index(sweep_points-1));
   }
   setForegroundColor(DEFAULT_FG_COLOR);
   setBackgroundColor(DEFAULT_BG_COLOR);

--- a/plot.c
+++ b/plot.c
@@ -425,7 +425,7 @@ logmag(const float *v)
 static float
 phase(const float *v)
 {
-  return 2 * atan2f(v[1], v[0]) / M_PI * 90;
+  return 2 * atan2f(v[1], v[0]) / VNA_PI * 90;
 }
 
 /*
@@ -438,9 +438,9 @@ groupdelay(const float *v, const float *w, float deltaf)
   // atan(w)-atan(v) = atan((w-v)/(1+wv))
   float r = w[0]*v[1] - w[1]*v[0];
   float i = w[0]*v[0] + w[1]*v[1];
-  return atan2f(r, i) / (2 * M_PI * deltaf);
+  return atan2f(r, i) / (2 * VNA_PI * deltaf);
 #else
-  return (atan2f(w[0], w[1]) - atan2f(v[0], v[1])) / (2 * M_PI * deltaf);
+  return (atan2f(w[0], w[1]) - atan2f(v[0], v[1])) / (2 * VNA_PI * deltaf);
 #endif
 }
 
@@ -605,11 +605,11 @@ format_smith_value(char *buf, int len, const float coeff[2], uint32_t frequency)
   case MS_RLC:
     if (zi < 0){// Capacity
       prefix = 'F';
-      value = -1 / (2 * M_PI * frequency * zi);
+      value = -1 / (2 * VNA_PI * frequency * zi);
     }
     else {
       prefix = 'H';
-      value = zi / (2 * M_PI * frequency);
+      value = zi / (2 * VNA_PI * frequency);
     }
     plot_printf(buf, len, "%F"S_OHM" %F%c", zr, value, prefix);
     break;

--- a/plot.c
+++ b/plot.c
@@ -1383,6 +1383,8 @@ draw_all(bool flush)
     draw_cal_status();
   if (redraw_request & REDRAW_BATTERY)
     draw_battery_status();
+  if (redraw_request & REDRAW_AREA)
+    force_set_markmap();
   redraw_request = 0;
 }
 
@@ -1398,6 +1400,8 @@ redraw_marker(int marker)
   markmap_upperarea();
 
   draw_all_cells(TRUE);
+  // Fores redraw all area after (disable artefacts after fast marker update area)
+  redraw_request|=REDRAW_AREA;
 }
 
 void

--- a/plot.c
+++ b/plot.c
@@ -811,7 +811,7 @@ mark_cells_from_index(void)
       int y0 = n0; int y1 = n1; if (y0>y1) SWAP(y0, y1); n0=n1;
       for (; y0<=y1; y0++)
         for(j=x0; j<=x1; j++)
-         map[y0]|= 1<<x0;
+         map[y0]|= 1<<j;
     }
   }
 }

--- a/plot.c
+++ b/plot.c
@@ -1373,9 +1373,11 @@ draw_all_cells(bool flush_markmap){
 void
 draw_all(bool flush)
 {
+  if (redraw_request & REDRAW_AREA)
+    force_set_markmap();
   if (redraw_request & REDRAW_MARKER)
     markmap_upperarea();
-  if (redraw_request & (REDRAW_CELLS | REDRAW_MARKER))
+  if (redraw_request & (REDRAW_CELLS | REDRAW_MARKER | REDRAW_AREA))
     draw_all_cells(flush);
   if (redraw_request & REDRAW_FREQUENCY)
     draw_frequencies();
@@ -1383,11 +1385,12 @@ draw_all(bool flush)
     draw_cal_status();
   if (redraw_request & REDRAW_BATTERY)
     draw_battery_status();
-  if (redraw_request & REDRAW_AREA)
-    force_set_markmap();
   redraw_request = 0;
 }
 
+//
+// Call this function then need fast draw marker and marker info
+// Used in ui.c for leveler move marker, drag marker and etc.
 void
 redraw_marker(int marker)
 {
@@ -1400,7 +1403,7 @@ redraw_marker(int marker)
   markmap_upperarea();
 
   draw_all_cells(TRUE);
-  // Fores redraw all area after (disable artefacts after fast marker update area)
+  // Force redraw all area after (disable artifacts after fast marker update area)
   redraw_request|=REDRAW_AREA;
 }
 

--- a/si5351.c
+++ b/si5351.c
@@ -41,7 +41,7 @@ static uint32_t current_freq = 0;
 
 // Minimum value is 2, freq change apply at next dsp measure, and need skip it
 #define DELAY_NORMAL       2
-// Delay for bands (depend set band 1 more fast (can change before next dsp bufer ready, need wait additional interval)
+// Delay for bands (depend set band 1 more fast (can change before next dsp buffer ready, need wait additional interval)
 #define DELAY_BAND_1       3
 #define DELAY_BAND_2       2
 // Band changes need set delay after reset PLL

--- a/si5351.c
+++ b/si5351.c
@@ -338,7 +338,7 @@ static inline uint8_t si5351_getBand(uint32_t freq){
 // Minimum value is 2, freq change apply at next dsp measure, and need skip it
 #define DELAY_NORMAL 2
 // Additional delay for band 1 (remove unstable generation at begin)
-#define DELAY_BAND_1	 1
+#define DELAY_BAND_1       1
 // Band changes need additional delay after reset PLL
 #define DELAY_BANDCHANGE_1 2
 #define DELAY_BANDCHANGE_2 2

--- a/si5351.c
+++ b/si5351.c
@@ -354,13 +354,13 @@ int
 si5351_set_frequency_with_offset(uint32_t freq, int offset, uint8_t drive_strength){
   uint8_t band;
   int delay = DELAY_NORMAL;
-  if (freq == current_freq)
-    return delay;
+//  if (freq == current_freq)
+//    return delay;
   uint32_t ofreq = freq + offset;
   uint32_t mul = 1, omul = 1;
   uint32_t rdiv = SI5351_R_DIV_1;
   uint32_t fdiv;
-  current_freq = freq;
+//  current_freq = freq;
   if (freq >= config.harmonic_freq_threshold * 7U) {
      mul =  9;
     omul = 11;

--- a/si5351.c
+++ b/si5351.c
@@ -65,13 +65,26 @@ si5351_bulk_write(const uint8_t *buf, int len)
   (void)i2cMasterTransmitTimeout(&I2CD1, SI5351_I2C_ADDR, buf, len, NULL, 0, 1000);
   i2cReleaseBus(&I2CD1);
 }
+
 #if 0
-static void si5351_bulk_read(uint8_t reg, uint8_t* buf, int len)
+static bool si5351_bulk_read(uint8_t reg, uint8_t* buf, int len)
 {
-  int addr = SI5351_I2C_ADDR>>1;
   i2cAcquireBus(&I2CD1);
-  msg_t mr = i2cMasterTransmitTimeout(&I2CD1, addr, &reg, 1, buf, len, 1000);
+  msg_t mr = i2cMasterTransmitTimeout(&I2CD1, SI5351_I2C_ADDR, &reg, 1, buf, len, 1000);
   i2cReleaseBus(&I2CD1);
+  return mr == MSG_OK;
+}
+
+static void si5351_wait_pll_lock(void)
+{
+  uint8_t status;
+  int count = 100;
+  do{
+    status=0xFF;
+    si5351_bulk_read(0, &status, 1);
+    if ((status & 0x60) == 0) // PLLA and PLLB locked
+      return;
+  }while (--count);
 }
 #endif
 

--- a/si5351.c
+++ b/si5351.c
@@ -380,13 +380,16 @@ si5351_set_frequency_with_offset(uint32_t freq, uint8_t drive_strength){
   int delay = DELAY_NORMAL;
   if (freq == current_freq)
     return delay;
+  else if (current_freq > freq)  // Reset band on sweep begin (if set range 150-600, fix error then 600 MHz band 2 or 3 go back)
+    current_band = 0;
+  current_freq = freq;
   uint32_t ofreq = freq + current_offset;
   uint32_t mul = 1, omul = 1;
   uint32_t rdiv = SI5351_R_DIV_1;
   uint32_t fdiv;
-  // Fix possible uncorrect input
+  // Fix possible incorrect input
   drive_strength&=SI5351_CLK_DRIVE_STRENGTH_MASK;
-  current_freq = freq;
+
   if (freq >= config.harmonic_freq_threshold * 7U) {
      mul =  9;
     omul = 11;

--- a/si5351.h
+++ b/si5351.h
@@ -72,4 +72,8 @@ void si5351_init(void);
 void si5351_disable_output(void);
 void si5351_enable_output(void);
 //void si5351_set_frequency(int channel, uint32_t freq, uint8_t drive_strength);
-int  si5351_set_frequency_with_offset(uint32_t freq, int offset, uint8_t drive_strength);
+
+void si5351_set_frequency_offset(int32_t offset);
+int  si5351_set_frequency_with_offset(uint32_t freq, uint8_t drive_strength);
+uint32_t si5351_getFrequency(void);
+

--- a/ui.c
+++ b/ui.c
@@ -1641,7 +1641,7 @@ lever_move_marker(int status)
         markers[active_marker].frequency = frequencies[markers[active_marker].index];
         redraw_marker(active_marker);
       }
-      if ((status & EVT_UP) && markers[active_marker].index < 100) {
+      if ((status & EVT_UP) && markers[active_marker].index < sweep_points-1) {
         markers[active_marker].index++;
         markers[active_marker].frequency = frequencies[markers[active_marker].index];
         redraw_marker(active_marker);

--- a/ui.c
+++ b/ui.c
@@ -2145,7 +2145,6 @@ void ui_process_touch(void)
       if (touch_pickup_marker())
         break;
       if (touch_lever_mode_select()) {
-        draw_all(FALSE);
         touch_wait_release();
         break;
       }

--- a/ui.c
+++ b/ui.c
@@ -1250,9 +1250,9 @@ draw_keypad(void)
 static void
 draw_numeric_area_frame(void)
 {
-  ili9341_fill(0, 240-NUM_INPUT_HEIGHT, 320, NUM_INPUT_HEIGHT, DEFAULT_MENU_COLOR);
+  ili9341_fill(0, 240-NUM_INPUT_HEIGHT, 320, NUM_INPUT_HEIGHT, config.menu_normal_color);
   setForegroundColor(DEFAULT_MENU_TEXT_COLOR);
-  setBackgroundColor(DEFAULT_MENU_COLOR);
+  setBackgroundColor(config.menu_normal_color);
   ili9341_drawstring(keypad_mode_label[keypad_mode], 10, 240-(FONT_GET_HEIGHT+NUM_INPUT_HEIGHT)/2);
   //ili9341_drawfont(KP_KEYPAD, 300, 216);
 }
@@ -1267,7 +1267,7 @@ draw_numeric_input(const char *buf)
 
   for (i = 0, x = 64; i < 10 && buf[i]; i++, xsim<<=1) {
     uint16_t fg = DEFAULT_MENU_TEXT_COLOR;
-    uint16_t bg = DEFAULT_MENU_COLOR;
+    uint16_t bg = config.menu_normal_color;
     int c = buf[i];
     if (c == '.')
       c = KP_PERIOD;
@@ -1294,7 +1294,7 @@ draw_numeric_input(const char *buf)
     x += xsim&0x8000 ? NUM_FONT_GET_WIDTH+2+8 : NUM_FONT_GET_WIDTH+2;
   }
   // erase last
-  ili9341_fill(x, 240-NUM_INPUT_HEIGHT+4, NUM_FONT_GET_WIDTH+2+8, NUM_FONT_GET_WIDTH+2+8, DEFAULT_MENU_COLOR);
+  ili9341_fill(x, 240-NUM_INPUT_HEIGHT+4, NUM_FONT_GET_WIDTH+2+8, NUM_FONT_GET_WIDTH+2+8, config.menu_normal_color);
 }
 
 static int

--- a/ui.c
+++ b/ui.c
@@ -2142,20 +2142,19 @@ void ui_process_touch(void)
   if (status == EVT_TOUCH_PRESSED || status == EVT_TOUCH_DOWN) {
     switch (ui_mode) {
     case UI_NORMAL:
+      // Try drag marker
       if (touch_pickup_marker())
         break;
+      // Try select lever mode (top and bottom screen)
       if (touch_lever_mode_select()) {
         touch_wait_release();
         break;
       }
-      
+      // switch menu mode after release
       touch_wait_release();
-
-      // switch menu mode
-      selection = -1;
+      selection = -1; // hide keyboard mode selection
       ui_mode_menu();
       break;
-
     case UI_MENU:
       menu_apply_touch();
       break;

--- a/ui.c
+++ b/ui.c
@@ -767,7 +767,7 @@ menu_marker_search_cb(int item, uint8_t data)
   if (i != -1)
     markers[active_marker].index = i;
   draw_menu();
-  redraw_marker(active_marker, TRUE);
+  redraw_marker(active_marker);
   select_lever_mode(LM_SEARCH);
 }
 
@@ -776,7 +776,7 @@ menu_marker_smith_cb(int item, uint8_t data)
 {
   (void)item;
   marker_smith_format = data;
-  redraw_marker(active_marker, TRUE);
+  redraw_marker(active_marker);
   draw_menu();
 }
 
@@ -822,7 +822,7 @@ menu_marker_sel_cb(int item, uint8_t data)
   } else if (item == 5) { /* marker delta */
     uistat.marker_delta = !uistat.marker_delta;
   }
-  redraw_marker(active_marker, TRUE);
+  redraw_marker(active_marker);
   draw_menu();
 }
 
@@ -1639,18 +1639,18 @@ lever_move_marker(int status)
       if ((status & EVT_DOWN) && markers[active_marker].index > 0) {
         markers[active_marker].index--;
         markers[active_marker].frequency = frequencies[markers[active_marker].index];
-        redraw_marker(active_marker, FALSE);
+        redraw_marker(active_marker);
       }
       if ((status & EVT_UP) && markers[active_marker].index < 100) {
         markers[active_marker].index++;
         markers[active_marker].frequency = frequencies[markers[active_marker].index];
-        redraw_marker(active_marker, FALSE);
+        redraw_marker(active_marker);
       }
     }
     status = btn_wait_release();
   } while (status != 0);
   if (active_marker >= 0)
-    redraw_marker(active_marker, TRUE);
+    redraw_marker(active_marker);
 }
 
 static void
@@ -1664,7 +1664,7 @@ lever_search_marker(int status)
       i = marker_search_right(markers[active_marker].index);
     if (i != -1)
       markers[active_marker].index = i;
-    redraw_marker(active_marker, TRUE);
+    redraw_marker(active_marker);
   }
 }
 
@@ -2067,7 +2067,7 @@ drag_marker(int t, int m)
     if (index >= 0) {
       markers[m].index = index;
       markers[m].frequency = frequencies[index];
-      redraw_marker(m, TRUE);
+      redraw_marker(m);
     }
   } while(touch_check()!=EVT_TOUCH_RELEASED);
 }
@@ -2097,7 +2097,7 @@ touch_pickup_marker(void)
         if (active_marker != m) {
           previous_marker = active_marker;
           active_marker = m;
-          redraw_marker(active_marker, TRUE);
+          redraw_marker(active_marker);
         }
         // select trace
         uistat.current_trace = t;


### PR DESCRIPTION
* Little code optimization
* Add commented 600kHz I2C bus timings (work, give x1.5 speed, but need change DSP ready timings not by wait_count, need use chVTGetSystemTimeX() its better)
Need select maximum ready time and check in on DSP ready.
For example:
tlv320aic3204_select need xxx time
set_frequency need yyy, in some times zzz
Need sellect maximum ready time and start dsp after, its allow more better optimise sweep
On 600kHz I2C bus speed set_frequency req only 440 sys tick (on 400kHz need 700), and in some cases can be faster then tlv320aic3204_select
* Fix screen artifacts
* Fix Random jitters at band 1 and band change on some freq ranges
* Change start/stop or center/span mode set
* Remove Mutex use (CH_CFG_USE_MUTEXES = FALSE), now all Mutex depend functions run in sweep thread
>It allow:
> reduce shell thread stack size
> more compact code
> fix some hardcoded scan command code, allow write better scan version
> run calibrate (not depend from pause sweep flag)
* Rewrite uint32_t my_atoui(const char *p), now its allow read:
hex 0xaAbBcC12
dec 12345678
bin 0b00011100
oct 0o12345678

* Implement color command, allow change color settings in config (enabled bu default ENABLE_COLOR_COMMAND)
>Usage: usage: color {id} {rgb24}
> Grid color: id = -3
> Menu bg color: id = -2
> Selected menu: id = -1
> Trace 1-4: id = 0..3

* Not use float in vbat measure (less size, more  faster)
* Fix 'frequencies' command, now output as uint32
* Extend scan command
> usage: scan {start(Hz)} {stop(Hz)} [points] [outmask]
> [outmask] - optional, allow output measured data, its a mask (allow dec, hex, bin, oct)
> 0b001 - output frequency
> 0b010 - output CH0 data
> 0b100 - output CH1 data
> Example:
> 'scan 1000000 5000000 101 0b111' - output data in format: freq ch0[0] ch0[1] ch1[0] ch1[1]
> 'scan 1000000 5000000 101 0b101' - output data in format: freq ch1[0] ch1[1]
> 'scan 1000000 5000000 101 0x7'   - output data as 0b111

* Fix interpolation range if sweep_points!=source calibration points count
use sweep_points exept POINTS_COUNT on marker search and so
Now possible change sweep_points in process (for faster sweep)

Add some comments